### PR TITLE
Add wait-time waterfall (P1a)

### DIFF
--- a/features/step-definitions/waitTime.steps.js
+++ b/features/step-definitions/waitTime.steps.js
@@ -1,0 +1,43 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { calculateWaitTimeBreakdown } from '../../src/utils/calculations/waitTime.js'
+
+const rowByName = (name) =>
+  calculateWaitTimeBreakdown(vsmDataStore.steps).steps.find((r) => r.name === name)
+
+Given(
+  'a manual approval step {string} with process time {int} and lead time {int}',
+  function (name, pt, lt) {
+    this.vsm.createVSM('Waterfall Map')
+    this.vsm.addStep(name, { processTime: pt, leadTime: lt, automated: false })
+  }
+)
+
+When('I view the wait-time waterfall', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+Then('I see a message to add steps for the waterfall', function () {
+  expect(vsmDataStore.steps).to.have.lengthOf(0)
+})
+
+Then('the wait-time waterfall shows {string} as {int}% waiting', function (name, percentage) {
+  expect(rowByName(name).waitPercentage).to.equal(percentage)
+})
+
+Then('{string} is flagged as a hidden queue', function (name) {
+  expect(rowByName(name).waitDominated).to.equal(true)
+})
+
+Then('{string} is not flagged as a hidden queue', function (name) {
+  expect(rowByName(name).waitDominated).to.equal(false)
+})
+
+Then('{string} is flagged as a handoff', function (name) {
+  expect(rowByName(name).manual).to.equal(true)
+})
+
+Then('the wait-time summary shows {int}% waiting', function (percentage) {
+  expect(calculateWaitTimeBreakdown(vsmDataStore.steps).totals.waitPercentage).to.equal(percentage)
+})

--- a/features/visualization/wait-time-waterfall.feature
+++ b/features/visualization/wait-time-waterfall.feature
@@ -1,0 +1,43 @@
+Feature: Wait-Time Waterfall
+  As a team facilitator
+  I want to see how much of each step's lead time is spent waiting
+  So that I can find the hidden queues and handoffs that slow delivery
+
+  Scenario: Empty stream prompts to add steps
+    Given an empty value stream map
+    When I view the wait-time waterfall
+    Then I see a message to add steps for the waterfall
+
+  Scenario: Splits a step into value-add and wait time
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 60          | 240      |
+    When I view the wait-time waterfall
+    Then the wait-time waterfall shows "Dev" as 75% waiting
+
+  Scenario: Flags a wait-dominated step as a hidden queue
+    Given a value stream with steps:
+      | name   | processTime | leadTime |
+      | Review | 10          | 200      |
+    When I view the wait-time waterfall
+    Then "Review" is flagged as a hidden queue
+
+  Scenario: Does not flag a value-add-dominated step
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 180         | 200      |
+    When I view the wait-time waterfall
+    Then "Dev" is not flagged as a hidden queue
+
+  Scenario: Flags a manual step as a handoff
+    Given a manual approval step "Sign-off" with process time 5 and lead time 480
+    When I view the wait-time waterfall
+    Then "Sign-off" is flagged as a handoff
+
+  Scenario: Summarises the overall wait percentage
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 60          | 240      |
+      | Test | 40          | 160      |
+    When I view the wait-time waterfall
+    Then the wait-time summary shows 75% waiting

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import WaitTimeWaterfall from './components/metrics/WaitTimeWaterfall.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -94,6 +95,7 @@
           </div>
           <SimulationPanel />
           <MetricsDashboard />
+          <WaitTimeWaterfall />
           <CdReadinessScorecard />
         </main>
         <EditorPanel

--- a/src/components/metrics/WaitTimeWaterfall.svelte
+++ b/src/components/metrics/WaitTimeWaterfall.svelte
@@ -1,0 +1,80 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { calculateWaitTimeBreakdown } from '../../utils/calculations/waitTime.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let breakdown = $derived(calculateWaitTimeBreakdown(steps))
+
+  function pct(value, total) {
+    return total > 0 ? (value / total) * 100 : 0
+  }
+</script>
+
+<details
+  class="bg-white border-t border-gray-200 px-6 py-4"
+  data-testid="wait-time-waterfall"
+  open
+>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Wait-Time Waterfall
+    {#if steps.length > 0}
+      <span class="ml-2 text-xs font-normal text-gray-500" data-testid="wait-time-summary">
+        {breakdown.totals.waitPercentage}% of lead time is waiting
+      </span>
+    {/if}
+  </summary>
+
+  {#if steps.length === 0}
+    <p class="mt-3 text-sm text-gray-500">
+      Add steps to your value stream to see where time is spent waiting.
+    </p>
+  {:else}
+    <ul class="mt-3 space-y-2">
+      {#each breakdown.steps as row (row.stepId)}
+        <li data-testid="wait-row-{row.stepId}" data-wait-dominated={row.waitDominated}>
+          <div class="flex items-center justify-between text-xs text-gray-700">
+            <span class="font-medium">
+              {row.name}
+              {#if row.manual}
+                <span
+                  class="ml-1 rounded bg-red-100 px-1 text-[10px] font-semibold text-red-700"
+                  data-testid="handoff-badge-{row.stepId}"
+                >
+                  handoff
+                </span>
+              {/if}
+              {#if row.waitDominated}
+                <span
+                  class="ml-1 rounded bg-amber-100 px-1 text-[10px] font-semibold text-amber-700"
+                  data-testid="hidden-queue-badge-{row.stepId}"
+                >
+                  hidden queue
+                </span>
+              {/if}
+            </span>
+            <span class="text-gray-500">{row.waitPercentage}% waiting</span>
+          </div>
+          <div class="mt-1 flex h-4 w-full overflow-hidden rounded bg-gray-100" aria-hidden="true">
+            <div
+              class="bg-green-500"
+              style="width: {pct(row.processTime, row.leadTime)}%"
+              title="Value-add: {formatDuration(row.processTime)}"
+            ></div>
+            <div
+              class="bg-amber-400"
+              style="width: {pct(row.waitTime, row.leadTime)}%"
+              title="Waiting: {formatDuration(row.waitTime)}"
+            ></div>
+          </div>
+        </li>
+      {/each}
+    </ul>
+    <p class="mt-3 text-xs text-gray-500">
+      <span class="inline-block h-2 w-2 rounded-sm bg-green-500"></span> value-add
+      ({formatDuration(breakdown.totals.processTime)})
+      <span class="ml-3 inline-block h-2 w-2 rounded-sm bg-amber-400"></span> waiting
+      ({formatDuration(breakdown.totals.waitTime)})
+    </p>
+  {/if}
+</details>

--- a/src/data/thresholds.js
+++ b/src/data/thresholds.js
@@ -33,6 +33,8 @@ export const PROGRESS_MULTIPLIER = 10
 export const WORK_ITEM_MAX_LEAD_TIME_MINUTES = 960
 // A test step's suite should run in under 10 minutes.
 export const TEST_STEP_MAX_PROCESS_TIME_MINUTES = 10
+// A step whose wait time is at/above this % of lead time is a hidden queue.
+export const WAIT_DOMINATED_THRESHOLD = 50
 
 // Canvas layout constants have been moved to canvasConfig.js
 // Re-exported here for backward compatibility

--- a/src/utils/calculations/waitTime.js
+++ b/src/utils/calculations/waitTime.js
@@ -1,0 +1,68 @@
+/**
+ * Wait-time waterfall (P1a)
+ *
+ * Splits each step's lead time into value-add (process) time and wait time,
+ * surfacing the hidden queues that dominate most value streams. Manual steps
+ * are flagged as handoffs — Phase 2 of beyond.minimumcd.org names manual gates
+ * and handoff delays as waste.
+ *
+ * Pure functions; all times in minutes.
+ */
+
+import { isAutomated } from '../../models/StepFactory.js'
+import { WAIT_DOMINATED_THRESHOLD } from '../../data/thresholds.js'
+
+/**
+ * @typedef {Object} WaitRow
+ * @property {string} stepId
+ * @property {string} name
+ * @property {number} processTime - Value-add minutes
+ * @property {number} waitTime - Wait minutes (leadTime - processTime, floored at 0)
+ * @property {number} leadTime
+ * @property {number} waitPercentage - Wait as a % of lead time (0 when leadTime is 0)
+ * @property {boolean} waitDominated - Wait percentage at/above the threshold
+ * @property {boolean} manual - Step is a manual handoff (a hidden queue)
+ */
+
+const waitPct = (waitTime, leadTime) => (leadTime > 0 ? (waitTime / leadTime) * 100 : 0)
+
+/**
+ * Break a value stream down into per-step value-add vs. wait time, with totals.
+ * @param {Array} steps
+ * @returns {{steps: WaitRow[], totals: {processTime:number, waitTime:number, leadTime:number, waitPercentage:number}}}
+ */
+export function calculateWaitTimeBreakdown(steps = []) {
+  const rows = steps.map((s) => {
+    const processTime = s.processTime || 0
+    const leadTime = s.leadTime || 0
+    const waitTime = Math.max(0, leadTime - processTime)
+    const percentage = waitPct(waitTime, leadTime)
+    return {
+      stepId: s.id,
+      name: s.name,
+      processTime,
+      waitTime,
+      leadTime,
+      waitPercentage: Number(percentage.toFixed(1)),
+      waitDominated: percentage >= WAIT_DOMINATED_THRESHOLD,
+      manual: !isAutomated(s),
+    }
+  })
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      processTime: acc.processTime + r.processTime,
+      waitTime: acc.waitTime + r.waitTime,
+      leadTime: acc.leadTime + r.leadTime,
+    }),
+    { processTime: 0, waitTime: 0, leadTime: 0 }
+  )
+
+  return {
+    steps: rows,
+    totals: {
+      ...totals,
+      waitPercentage: Number(waitPct(totals.waitTime, totals.leadTime).toFixed(1)),
+    },
+  }
+}

--- a/tests/unit/calculations/waitTime.test.js
+++ b/tests/unit/calculations/waitTime.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { calculateWaitTimeBreakdown } from '../../../src/utils/calculations/waitTime'
+
+const step = (o) => ({
+  id: 'x',
+  name: 'Step',
+  type: 'development',
+  processTime: 60,
+  leadTime: 240,
+  automated: true,
+  ...o,
+})
+
+describe('calculateWaitTimeBreakdown', () => {
+  it('returns no rows for an empty stream', () => {
+    const result = calculateWaitTimeBreakdown([])
+    expect(result.steps).toEqual([])
+    expect(result.totals.leadTime).toBe(0)
+  })
+
+  it('splits each step into value-add and wait time', () => {
+    const row = calculateWaitTimeBreakdown([step({ id: 'a', processTime: 60, leadTime: 240 })]).steps[0]
+    expect(row.processTime).toBe(60)
+    expect(row.waitTime).toBe(180)
+    expect(row.waitPercentage).toBe(75)
+  })
+
+  it('never reports negative wait when process exceeds lead time', () => {
+    const row = calculateWaitTimeBreakdown([step({ processTime: 100, leadTime: 60 })]).steps[0]
+    expect(row.waitTime).toBe(0)
+    expect(row.waitPercentage).toBe(0)
+  })
+
+  it('flags a wait-dominated step as a hidden queue', () => {
+    const row = calculateWaitTimeBreakdown([step({ processTime: 10, leadTime: 200 })]).steps[0]
+    expect(row.waitDominated).toBe(true)
+  })
+
+  it('does not flag a value-add-dominated step', () => {
+    const row = calculateWaitTimeBreakdown([step({ processTime: 180, leadTime: 200 })]).steps[0]
+    expect(row.waitDominated).toBe(false)
+  })
+
+  it('flags a manual step as a handoff', () => {
+    const row = calculateWaitTimeBreakdown([step({ automated: false })]).steps[0]
+    expect(row.manual).toBe(true)
+  })
+
+  it('treats a step with no automated property as automated (not a handoff)', () => {
+    const s = step({})
+    delete s.automated
+    expect(calculateWaitTimeBreakdown([s]).steps[0].manual).toBe(false)
+  })
+
+  it('totals process, wait, and lead time across steps', () => {
+    const { totals } = calculateWaitTimeBreakdown([
+      step({ id: 'a', processTime: 60, leadTime: 240 }),
+      step({ id: 'b', processTime: 40, leadTime: 160 }),
+    ])
+    expect(totals.processTime).toBe(100)
+    expect(totals.waitTime).toBe(300)
+    expect(totals.leadTime).toBe(400)
+    expect(totals.waitPercentage).toBe(75)
+  })
+})


### PR DESCRIPTION
## What

Adds the **P1a Wait-Time Waterfall** from the CD Readiness Diagnosis roadmap (`HANDOFF-vsm-review.md`). It splits each step's lead time into **value-add (process) time vs. wait time**, surfacing the hidden queues that dominate most value streams.

- Flags **wait-dominated** steps (≥50% of lead time waiting) as *hidden queues*.
- Flags **manual** steps (`automated === false`) as *handoffs* — Phase 2 of beyond.minimumcd.org explicitly names manual gates and handoff delays as waste.
- Shows an overall **wait-percentage** summary.

## How

- `src/utils/calculations/waitTime.js` — pure `calculateWaitTimeBreakdown(steps)` returning per-step value-add/wait split + totals; reuses the `automated` flag and a new `WAIT_DOMINATED_THRESHOLD`.
- `src/components/metrics/WaitTimeWaterfall.svelte` — collapsible panel with a value-add/wait bar per step, handoff/hidden-queue badges, mounted below the metrics dashboard.

## Tests

- 8 unit tests (split, negative-wait floor, thresholds, manual/legacy, totals).
- 6 acceptance scenarios (`features/visualization/wait-time-waterfall.feature`).
- Quality gate green: 435 unit tests, build, lint.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_