### PR TITLE
Add DORA reconciliation (P1c)

### DIFF
--- a/features/step-definitions/dora.steps.js
+++ b/features/step-definitions/dora.steps.js
@@ -1,0 +1,37 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import {
+  reconcileLeadTime,
+  classifyDora,
+} from '../../src/utils/calculations/doraReconciliation.js'
+
+const reconciliation = () => reconcileLeadTime(vsmDataStore.steps, vsmDataStore.dora)
+
+When('I view the DORA panel', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+When('I record an actual lead time for changes of {int} minutes', function (minutes) {
+  vsmDataStore.setDora({ leadTimeForChangesMinutes: minutes })
+})
+
+When('I record the following DORA metrics:', function (dataTable) {
+  const updates = {}
+  dataTable.raw().forEach(([key, value]) => {
+    updates[key] = Number(value)
+  })
+  vsmDataStore.setDora(updates)
+})
+
+Then('the lead-time reconciliation status is {string}', function (status) {
+  expect(reconciliation().status).to.equal(status)
+})
+
+Then('the lead-time reconciliation shows a hidden queue of {int} minutes', function (minutes) {
+  expect(reconciliation().hiddenQueue).to.equal(minutes)
+})
+
+Then('the {string} DORA metric is rated {string}', function (metric, tier) {
+  expect(classifyDora(vsmDataStore.dora)[metric]).to.equal(tier)
+})

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -8,6 +8,7 @@ import { createStep } from '../../../src/models/StepFactory.js'
 import { createConnection } from '../../../src/models/ConnectionFactory.js'
 import { calculateMetrics } from '../../../src/utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../../../src/utils/calculations/cdReadiness.js'
+import { emptyDora } from '../../../src/utils/calculations/doraReconciliation.js'
 import { EXAMPLE_MAP } from '../../../src/data/exampleMaps.js'
 // MAP_TEMPLATES is available if needed for template loading tests
 
@@ -23,6 +24,7 @@ function createTestVsmDataStore() {
   let createdAt = null
   let updatedAt = null
   let readinessOverrides = {}
+  let dora = emptyDora()
 
   return {
     get id() {
@@ -55,6 +57,12 @@ function createTestVsmDataStore() {
     get readinessOverrides() {
       return readinessOverrides
     },
+    get dora() {
+      return dora
+    },
+    setDora(updates) {
+      dora = { ...dora, ...updates }
+    },
 
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -66,6 +74,7 @@ function createTestVsmDataStore() {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      dora = emptyDora()
     },
 
     setReadinessOverride(itemId, status) {
@@ -101,6 +110,7 @@ function createTestVsmDataStore() {
       createdAt = mapData.createdAt
       updatedAt = mapData.updatedAt
       readinessOverrides = mapData.readinessOverrides || {}
+      dora = mapData.dora || emptyDora()
     },
 
     clearMap() {
@@ -112,6 +122,7 @@ function createTestVsmDataStore() {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      dora = emptyDora()
     },
 
     addStep(stepName = 'New Step', overrides = {}) {
@@ -310,6 +321,7 @@ function createTestVsmIOStore(dataStore) {
         createdAt: dataStore.createdAt,
         updatedAt: dataStore.updatedAt,
         readinessOverrides: dataStore.readinessOverrides,
+        dora: dataStore.dora,
       })
     },
 

--- a/features/visualization/dora-reconciliation.feature
+++ b/features/visualization/dora-reconciliation.feature
@@ -1,0 +1,44 @@
+Feature: DORA Reconciliation
+  As a team facilitator running a Phase 0 assessment
+  I want to record our DORA metrics and compare actual lead time to the map
+  So that I can find the hidden queue the value stream does not yet show
+
+  Scenario: Reconciliation is unknown until an actual lead time is recorded
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 480      |
+    When I view the DORA panel
+    Then the lead-time reconciliation status is "unknown"
+
+  Scenario: A much larger actual lead time reveals a hidden queue
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 480      |
+    When I record an actual lead time for changes of 4800 minutes
+    Then the lead-time reconciliation status is "hidden-queue"
+    And the lead-time reconciliation shows a hidden queue of 4320 minutes
+
+  Scenario: A close actual lead time is aligned
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 1000     |
+    When I record an actual lead time for changes of 1100 minutes
+    Then the lead-time reconciliation status is "aligned"
+
+  Scenario: Classifies elite performance
+    Given an empty value stream map
+    When I record the following DORA metrics:
+      | deploymentFrequencyPerDay | 5   |
+      | leadTimeForChangesMinutes | 600 |
+      | changeFailureRatePct      | 10  |
+      | mttrMinutes               | 30  |
+    Then the "leadTimeForChanges" DORA metric is rated "elite"
+    And the "changeFailureRate" DORA metric is rated "elite"
+
+  Scenario: DORA metrics survive save and reload
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 480      |
+    And I record an actual lead time for changes of 4800 minutes
+    When the map is saved and reloaded
+    Then the lead-time reconciliation shows a hidden queue of 4320 minutes

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import DoraPanel from './components/metrics/DoraPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <DoraPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/DoraPanel.svelte
+++ b/src/components/metrics/DoraPanel.svelte
@@ -1,0 +1,87 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import {
+    reconcileLeadTime,
+    classifyDora,
+  } from '../../utils/calculations/doraReconciliation.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let dora = $derived(vsmDataStore.dora)
+  let reconciliation = $derived(reconcileLeadTime(steps, dora))
+  let tiers = $derived(classifyDora(dora))
+
+  const tierColors = {
+    elite: 'bg-green-100 text-green-800',
+    high: 'bg-blue-100 text-blue-800',
+    medium: 'bg-amber-100 text-amber-800',
+    low: 'bg-red-100 text-red-800',
+    unknown: 'bg-gray-100 text-gray-600',
+  }
+
+  const reconColors = {
+    'hidden-queue': 'text-red-700',
+    'optimistic-map': 'text-amber-700',
+    aligned: 'text-green-700',
+    unknown: 'text-gray-600',
+  }
+
+  // Number input that writes null when blank.
+  function onInput(field, raw) {
+    const value = raw === '' ? null : Number(raw)
+    vsmDataStore.setDora({ [field]: value })
+  }
+
+  const fields = [
+    { key: 'deploymentFrequencyPerDay', label: 'Deploy freq (per day)', tier: 'deploymentFrequency' },
+    { key: 'leadTimeForChangesMinutes', label: 'Lead time for changes (min)', tier: 'leadTimeForChanges' },
+    { key: 'changeFailureRatePct', label: 'Change failure rate (%)', tier: 'changeFailureRate' },
+    { key: 'mttrMinutes', label: 'MTTR (min)', tier: 'mttr' },
+  ]
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="dora-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">DORA Reconciliation</summary>
+
+  <div class="mt-3 grid grid-cols-2 gap-3 md:grid-cols-4">
+    {#each fields as f (f.key)}
+      <label class="block text-xs font-medium text-gray-700">
+        {f.label}
+        <input
+          type="number"
+          min="0"
+          value={dora[f.key] ?? ''}
+          oninput={(e) => onInput(f.key, e.target.value)}
+          class="mt-1 w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          data-testid="dora-input-{f.key}"
+        />
+        <span
+          class="mt-1 inline-block rounded px-1 text-[10px] font-semibold uppercase {tierColors[tiers[f.tier]]}"
+          data-testid="dora-tier-{f.tier}"
+        >
+          {tiers[f.tier]}
+        </span>
+      </label>
+    {/each}
+  </div>
+
+  <div class="mt-3 rounded-md bg-gray-50 p-3 text-xs" data-testid="dora-reconciliation" data-status={reconciliation.status}>
+    {#if reconciliation.status === 'unknown'}
+      <p class="text-gray-600">Enter the actual lead time for changes to reconcile it against the map.</p>
+    {:else}
+      <p>
+        VSM-derived lead time: <strong>{formatDuration(reconciliation.vsmLeadTime)}</strong>
+        · Actual: <strong>{formatDuration(reconciliation.actualLeadTime)}</strong>
+      </p>
+      <p class="mt-1 {reconColors[reconciliation.status]}">
+        {#if reconciliation.status === 'hidden-queue'}
+          Hidden queue of <strong>{formatDuration(reconciliation.hiddenQueue)}</strong> the map does not yet show.
+        {:else if reconciliation.status === 'optimistic-map'}
+          The map shows more lead time than reality — check the step estimates.
+        {:else}
+          Map and actual lead time are aligned.
+        {/if}
+      </p>
+    {/if}
+  </div>
+</details>

--- a/src/infrastructure/VsmJsonRepository.js
+++ b/src/infrastructure/VsmJsonRepository.js
@@ -17,9 +17,10 @@
  * @returns {string} JSON string representation
  */
 export function serializeVsm(vsm) {
-  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides } = vsm
+  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, dora } =
+    vsm
   return JSON.stringify(
-    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides },
+    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, dora },
     null,
     2
   )
@@ -70,5 +71,6 @@ export function deserializeVsm(jsonString) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    dora: data.dora && typeof data.dora === 'object' ? data.dora : undefined,
   }
 }

--- a/src/stores/vsmDataStore.svelte.js
+++ b/src/stores/vsmDataStore.svelte.js
@@ -9,6 +9,7 @@ import { createStep } from '../models/StepFactory.js'
 import { createConnection } from '../models/ConnectionFactory.js'
 import { calculateMetrics } from '../utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../utils/calculations/cdReadiness.js'
+import { emptyDora } from '../utils/calculations/doraReconciliation.js'
 import { sanitizeVSMData, validateVSMData } from '../utils/validation/vsmValidator.js'
 import { autoPositionStep } from '../utils/ui/autoPositionStep.js'
 import { vsmLocalStorageRepo } from '../infrastructure/VsmLocalStorageRepository.js'
@@ -34,6 +35,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
     createdAt: null,
     updatedAt: null,
     readinessOverrides: {},
+    dora: emptyDora(),
   }
 
   // Load persisted state; sanitize on read and validate to catch corrupted localStorage
@@ -51,6 +53,8 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
   let updatedAt = $state(persisted.updatedAt)
   // User confirm/override decisions for the CD readiness scorecard, keyed by item id
   let readinessOverrides = $state(persisted.readinessOverrides || {})
+  // DORA metrics for this map (P1c)
+  let dora = $state(persisted.dora || emptyDora())
 
   // Cached metrics — only recomputed when steps or connections change
   let cachedMetrics = $derived(calculateMetrics(steps, connections))
@@ -71,6 +75,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt,
       updatedAt,
       readinessOverrides,
+      dora,
     })
   }
 
@@ -113,6 +118,11 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       return readinessOverrides
     },
 
+    // DORA metrics for this map
+    get dora() {
+      return dora
+    },
+
     // Map-level Actions
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -124,6 +134,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      dora = emptyDora()
       persist()
     },
 
@@ -153,6 +164,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = safe.createdAt
       updatedAt = safe.updatedAt
       readinessOverrides = safe.readinessOverrides || {}
+      dora = safe.dora || emptyDora()
       persist()
     },
 
@@ -165,6 +177,14 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      dora = emptyDora()
+      persist()
+    },
+
+    // Update this map's DORA metrics (P1c)
+    setDora(updates) {
+      dora = { ...dora, ...updates }
+      updatedAt = new Date().toISOString()
       persist()
     },
 

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -112,6 +112,7 @@ function createVsmIOStore() {
         createdAt: vsmDataStore.createdAt,
         updatedAt: vsmDataStore.updatedAt,
         readinessOverrides: vsmDataStore.readinessOverrides,
+        dora: vsmDataStore.dora,
       })
     },
 

--- a/src/utils/calculations/doraReconciliation.js
+++ b/src/utils/calculations/doraReconciliation.js
@@ -1,0 +1,94 @@
+/**
+ * DORA reconciliation (P1c)
+ *
+ * Captures the four DORA metrics per map and reconciles the VSM-derived lead
+ * time against the actual lead time for changes. The gap between them is the
+ * hidden queue the map does not yet model — the strongest Phase-0 "Assess"
+ * signal that a value stream is incomplete.
+ *
+ * Pure functions. Durations in minutes; rates as 0-100 percentages;
+ * deployment frequency as deploys per (calendar) day.
+ */
+
+import { calculateTotalLeadTime } from './metrics.js'
+
+const ONE_DAY = 1440 // minutes
+const ONE_WEEK = ONE_DAY * 7
+const ONE_MONTH = ONE_DAY * 30
+
+/** A blank DORA record (all metrics unknown). */
+export const emptyDora = () => ({
+  deploymentFrequencyPerDay: null,
+  leadTimeForChangesMinutes: null,
+  changeFailureRatePct: null,
+  mttrMinutes: null,
+})
+
+// Actual lead time within this ratio of the VSM-derived total counts as aligned.
+const ALIGNED_RATIO = 1.5
+
+/**
+ * Reconcile the VSM-derived lead time against the recorded actual lead time.
+ * @param {Array} steps
+ * @param {Object} dora
+ * @returns {{vsmLeadTime:number, actualLeadTime:(number|null), hiddenQueue:number, ratio:(number|null), status:string}}
+ */
+export function reconcileLeadTime(steps = [], dora = emptyDora()) {
+  const vsmLeadTime = calculateTotalLeadTime(steps)
+  const actualLeadTime = dora?.leadTimeForChangesMinutes ?? null
+
+  if (actualLeadTime === null) {
+    return { vsmLeadTime, actualLeadTime: null, hiddenQueue: 0, ratio: null, status: 'unknown' }
+  }
+
+  const hiddenQueue = Math.max(0, actualLeadTime - vsmLeadTime)
+  const ratio = vsmLeadTime > 0 ? actualLeadTime / vsmLeadTime : null
+
+  let status
+  if (actualLeadTime < vsmLeadTime) status = 'optimistic-map'
+  else if (ratio !== null && ratio <= ALIGNED_RATIO) status = 'aligned'
+  else status = 'hidden-queue'
+
+  return { vsmLeadTime, actualLeadTime, hiddenQueue, ratio, status }
+}
+
+const tier = (value, { elite, high, medium }, lowerIsBetter = true) => {
+  if (value === null || value === undefined) return 'unknown'
+  if (lowerIsBetter) {
+    if (value <= elite) return 'elite'
+    if (value <= high) return 'high'
+    if (value <= medium) return 'medium'
+    return 'low'
+  }
+  if (value >= elite) return 'elite'
+  if (value >= high) return 'high'
+  if (value >= medium) return 'medium'
+  return 'low'
+}
+
+/**
+ * Classify each DORA metric into an elite/high/medium/low tier.
+ * Bands follow the DORA "Accelerate" performance clusters.
+ * @param {Object} dora
+ * @returns {{deploymentFrequency:string, leadTimeForChanges:string, changeFailureRate:string, mttr:string}}
+ */
+export function classifyDora(dora = emptyDora()) {
+  return {
+    // deploys per day — higher is better
+    deploymentFrequency: tier(
+      dora.deploymentFrequencyPerDay,
+      { elite: 1, high: 1 / 7, medium: 1 / 30 },
+      false
+    ),
+    // lead time for changes (minutes) — lower is better
+    leadTimeForChanges: tier(dora.leadTimeForChangesMinutes, {
+      elite: ONE_DAY,
+      high: ONE_WEEK,
+      medium: ONE_MONTH,
+    }),
+    // change failure rate (%) — lower is better
+    changeFailureRate: tier(dora.changeFailureRatePct, { elite: 15, high: 20, medium: 30 }),
+    // mttr (minutes) — lower is better
+    mttr: tier(dora.mttrMinutes, { elite: 60, high: ONE_DAY, medium: ONE_WEEK }),
+  }
+}

--- a/src/utils/validation/vsmValidator.js
+++ b/src/utils/validation/vsmValidator.js
@@ -128,5 +128,9 @@ export function sanitizeVSMData(data) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    dora:
+      data.dora && typeof data.dora === 'object' && !Array.isArray(data.dora)
+        ? data.dora
+        : undefined,
   }
 }

--- a/tests/unit/calculations/doraReconciliation.test.js
+++ b/tests/unit/calculations/doraReconciliation.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  reconcileLeadTime,
+  classifyDora,
+  emptyDora,
+} from '../../../src/utils/calculations/doraReconciliation'
+
+const step = (leadTime) => ({ id: 'x', name: 'S', processTime: 30, leadTime })
+
+describe('reconcileLeadTime', () => {
+  it('is unknown when no actual lead time is recorded', () => {
+    const r = reconcileLeadTime([step(240)], emptyDora())
+    expect(r.status).toBe('unknown')
+  })
+
+  it('flags a hidden queue when actual lead time far exceeds the VSM-derived total', () => {
+    const r = reconcileLeadTime([step(480)], { ...emptyDora(), leadTimeForChangesMinutes: 4800 })
+    expect(r.vsmLeadTime).toBe(480)
+    expect(r.actualLeadTime).toBe(4800)
+    expect(r.hiddenQueue).toBe(4320)
+    expect(r.status).toBe('hidden-queue')
+  })
+
+  it('reports aligned when actual and VSM lead times are close', () => {
+    const r = reconcileLeadTime([step(1000)], { ...emptyDora(), leadTimeForChangesMinutes: 1100 })
+    expect(r.status).toBe('aligned')
+    expect(r.hiddenQueue).toBe(100)
+  })
+
+  it('reports an optimistic map when actual is below the VSM-derived total', () => {
+    const r = reconcileLeadTime([step(1000)], { ...emptyDora(), leadTimeForChangesMinutes: 500 })
+    expect(r.status).toBe('optimistic-map')
+    expect(r.hiddenQueue).toBe(0)
+  })
+})
+
+describe('classifyDora', () => {
+  it('returns unknown tiers for an empty record', () => {
+    const tiers = classifyDora(emptyDora())
+    expect(tiers.leadTimeForChanges).toBe('unknown')
+    expect(tiers.deploymentFrequency).toBe('unknown')
+    expect(tiers.changeFailureRate).toBe('unknown')
+    expect(tiers.mttr).toBe('unknown')
+  })
+
+  it('classifies elite performance', () => {
+    const tiers = classifyDora({
+      deploymentFrequencyPerDay: 5,
+      leadTimeForChangesMinutes: 600,
+      changeFailureRatePct: 10,
+      mttrMinutes: 30,
+    })
+    expect(tiers.deploymentFrequency).toBe('elite')
+    expect(tiers.leadTimeForChanges).toBe('elite')
+    expect(tiers.changeFailureRate).toBe('elite')
+    expect(tiers.mttr).toBe('elite')
+  })
+
+  it('classifies low performance', () => {
+    const tiers = classifyDora({
+      deploymentFrequencyPerDay: 0.01,
+      leadTimeForChangesMinutes: 60000,
+      changeFailureRatePct: 45,
+      mttrMinutes: 20000,
+    })
+    expect(tiers.deploymentFrequency).toBe('low')
+    expect(tiers.leadTimeForChanges).toBe('low')
+    expect(tiers.changeFailureRate).toBe('low')
+    expect(tiers.mttr).toBe('low')
+  })
+})


### PR DESCRIPTION
## What

Adds **P1c DORA reconciliation** — the third leg of the Phase-0 "Assess" triad (map + practices + DORA). Captures the four DORA metrics per map and runs the **killer check**: VSM-derived lead time vs. **actual** lead time for changes. The delta is the *hidden queue* the map doesn't yet model.

- **Lead-time reconciliation** → `hidden-queue` / `aligned` / `optimistic-map` / `unknown`, with the hidden-queue magnitude.
- **Tier classification** of each metric (deploy frequency, lead time for changes, change failure rate, MTTR) into elite/high/medium/low per the DORA "Accelerate" clusters.

## How

- `src/utils/calculations/doraReconciliation.js` — pure `reconcileLeadTime`, `classifyDora`, `emptyDora`; reuses `calculateTotalLeadTime`.
- Persisted per-map `dora` record threaded through `vsmDataStore`, `sanitizeVSMData`, the JSON repository (export/import), and the cucumber test double — survives save/load and import/export.
- `src/components/metrics/DoraPanel.svelte` — metric inputs, tier badges, reconciliation summary.

## Tests

- 7 unit tests (reconciliation statuses, tier bands).
- 5 acceptance scenarios incl. persistence round-trip (`features/visualization/dora-reconciliation.feature`).
- Gate green: 434 unit tests, build, lint.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_