### PR TITLE
Add Kaizen-burst improvement annotations

### DIFF
--- a/features/builder/kaizen-annotations.feature
+++ b/features/builder/kaizen-annotations.feature
@@ -1,0 +1,37 @@
+Feature: Kaizen-Burst Annotations
+  As a team facilitator
+  I want to tag improvement opportunities on steps and edges
+  So that the value stream rolls up into a prioritized improvement backlog
+
+  Background:
+    Given a value stream with steps:
+      | name   | leadTime |
+      | Dev    | 240      |
+      | Review | 480      |
+
+  Scenario: Annotate a step with a waste type
+    When I annotate the "Review" step with "waiting" waste noted "Long approval queue"
+    Then the improvement backlog has 1 kaizen burst
+    And the backlog has 1 "waiting" annotation
+
+  Scenario: Roll up annotations by waste type
+    When I annotate the "Review" step with "waiting" waste noted "queue"
+    And I annotate the "Dev" step with "waiting" waste noted "blocked"
+    And I annotate the "Review" step with "rework" waste noted "bounces back"
+    Then the backlog has 2 "waiting" annotations
+    And the backlog has 1 "rework" annotation
+
+  Scenario: Remove an annotation from the backlog
+    When I annotate the "Review" step with "handoff" waste noted "manual"
+    And I remove that annotation
+    Then the improvement backlog has 0 kaizen bursts
+
+  Scenario: Deleting a step prunes its annotations
+    When I annotate the "Review" step with "waiting" waste noted "queue"
+    And I delete the "Review" step
+    Then the improvement backlog has 0 kaizen bursts
+
+  Scenario: Annotations survive save and reload
+    When I annotate the "Review" step with "waiting" waste noted "queue"
+    And the map is saved and reloaded
+    Then the improvement backlog has 1 kaizen burst

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -8,6 +8,7 @@ import { createStep } from '../../../src/models/StepFactory.js'
 import { createConnection } from '../../../src/models/ConnectionFactory.js'
 import { calculateMetrics } from '../../../src/utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../../../src/utils/calculations/cdReadiness.js'
+import { createAnnotation } from '../../../src/utils/annotations.js'
 import { EXAMPLE_MAP } from '../../../src/data/exampleMaps.js'
 // MAP_TEMPLATES is available if needed for template loading tests
 
@@ -23,6 +24,7 @@ function createTestVsmDataStore() {
   let createdAt = null
   let updatedAt = null
   let readinessOverrides = {}
+  let annotations = []
 
   return {
     get id() {
@@ -55,6 +57,17 @@ function createTestVsmDataStore() {
     get readinessOverrides() {
       return readinessOverrides
     },
+    get annotations() {
+      return annotations
+    },
+    addAnnotation(targetType, targetId, wasteType, note = '') {
+      const annotation = createAnnotation(targetType, targetId, wasteType, note)
+      annotations = [...annotations, annotation]
+      return annotation
+    },
+    removeAnnotation(annotationId) {
+      annotations = annotations.filter((a) => a.id !== annotationId)
+    },
 
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -66,6 +79,7 @@ function createTestVsmDataStore() {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      annotations = []
     },
 
     setReadinessOverride(itemId, status) {
@@ -101,6 +115,7 @@ function createTestVsmDataStore() {
       createdAt = mapData.createdAt
       updatedAt = mapData.updatedAt
       readinessOverrides = mapData.readinessOverrides || {}
+      annotations = mapData.annotations || []
     },
 
     clearMap() {
@@ -112,6 +127,7 @@ function createTestVsmDataStore() {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      annotations = []
     },
 
     addStep(stepName = 'New Step', overrides = {}) {
@@ -133,9 +149,17 @@ function createTestVsmDataStore() {
     },
 
     deleteStep(stepId) {
+      const removedConnectionIds = connections
+        .filter((conn) => conn.source === stepId || conn.target === stepId)
+        .map((conn) => conn.id)
       steps = steps.filter((step) => step.id !== stepId)
       connections = connections.filter(
         (conn) => conn.source !== stepId && conn.target !== stepId
+      )
+      annotations = annotations.filter(
+        (a) =>
+          !(a.targetType === 'step' && a.targetId === stepId) &&
+          !(a.targetType === 'connection' && removedConnectionIds.includes(a.targetId))
       )
       updatedAt = new Date().toISOString()
     },
@@ -310,6 +334,7 @@ function createTestVsmIOStore(dataStore) {
         createdAt: dataStore.createdAt,
         updatedAt: dataStore.updatedAt,
         readinessOverrides: dataStore.readinessOverrides,
+        annotations: dataStore.annotations,
       })
     },
 

--- a/features/step-definitions/kaizen.steps.js
+++ b/features/step-definitions/kaizen.steps.js
@@ -1,0 +1,34 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import {
+  groupAnnotationsByWaste,
+  summarizeAnnotations,
+} from '../../src/utils/annotations.js'
+
+const stepByName = (name) => vsmDataStore.steps.find((s) => s.name === name)
+
+When(
+  'I annotate the {string} step with {string} waste noted {string}',
+  function (stepName, wasteType, note) {
+    const step = stepByName(stepName)
+    this.lastAnnotation = vsmDataStore.addAnnotation('step', step.id, wasteType, note)
+  }
+)
+
+When('I remove that annotation', function () {
+  vsmDataStore.removeAnnotation(this.lastAnnotation.id)
+})
+
+When('I delete the {string} step', function (stepName) {
+  vsmDataStore.deleteStep(stepByName(stepName).id)
+})
+
+Then('the improvement backlog has {int} kaizen burst(s)', function (count) {
+  expect(summarizeAnnotations(vsmDataStore.annotations).total).to.equal(count)
+})
+
+Then('the backlog has {int} {string} annotation(s)', function (count, wasteType) {
+  const group = groupAnnotationsByWaste(vsmDataStore.annotations)[wasteType] || []
+  expect(group).to.have.lengthOf(count)
+})

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import AnnotationsPanel from './components/metrics/AnnotationsPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <AnnotationsPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/AnnotationsPanel.svelte
+++ b/src/components/metrics/AnnotationsPanel.svelte
@@ -1,0 +1,133 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { WASTE_TYPES, WASTE_TYPE_LABELS } from '../../data/wasteTypes.js'
+  import {
+    groupAnnotationsByWaste,
+    summarizeAnnotations,
+  } from '../../utils/annotations.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let connections = $derived(vsmDataStore.connections)
+  let annotations = $derived(vsmDataStore.annotations)
+  let grouped = $derived(groupAnnotationsByWaste(annotations))
+  let summary = $derived(summarizeAnnotations(annotations))
+
+  let targetId = $state('')
+  let wasteType = $state(WASTE_TYPES.WAITING)
+  let note = $state('')
+
+  // Targets the user can annotate: steps and connections (labelled by step names).
+  let targets = $derived([
+    ...steps.map((s) => ({ id: s.id, type: 'step', label: `Step: ${s.name}` })),
+    ...connections.map((c) => ({
+      id: c.id,
+      type: 'connection',
+      label: `Edge: ${stepName(c.source)} → ${stepName(c.target)}`,
+    })),
+  ])
+
+  function stepName(id) {
+    return steps.find((s) => s.id === id)?.name ?? '?'
+  }
+
+  function targetLabel(annotation) {
+    return targets.find((t) => t.id === annotation.targetId)?.label ?? '(removed)'
+  }
+
+  function handleAdd() {
+    const target = targets.find((t) => t.id === targetId)
+    if (!target) return
+    vsmDataStore.addAnnotation(target.type, target.id, wasteType, note.trim())
+    note = ''
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="annotations-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Improvement Backlog
+    <span class="ml-2 text-xs font-normal text-gray-500" data-testid="annotations-summary">
+      {summary.total} kaizen {summary.total === 1 ? 'burst' : 'bursts'}
+    </span>
+  </summary>
+
+  {#if targets.length === 0}
+    <p class="mt-3 text-sm text-gray-500">Add steps to annotate improvement opportunities.</p>
+  {:else}
+    <div class="mt-3 flex flex-wrap items-end gap-2">
+      <label class="text-xs font-medium text-gray-700">
+        Target
+        <select
+          bind:value={targetId}
+          class="mt-1 block rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="annotation-target-select"
+        >
+          <option value="" disabled>Choose…</option>
+          {#each targets as t (t.id)}
+            <option value={t.id}>{t.label}</option>
+          {/each}
+        </select>
+      </label>
+      <label class="text-xs font-medium text-gray-700">
+        Waste
+        <select
+          bind:value={wasteType}
+          class="mt-1 block rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="annotation-waste-select"
+        >
+          {#each Object.entries(WASTE_TYPE_LABELS) as [value, label] (value)}
+            <option {value}>{label}</option>
+          {/each}
+        </select>
+      </label>
+      <input
+        bind:value={note}
+        placeholder="Note (optional)"
+        class="flex-1 rounded-md border border-gray-300 px-2 py-1 text-sm"
+        data-testid="annotation-note-input"
+      />
+      <button
+        type="button"
+        onclick={handleAdd}
+        disabled={!targetId}
+        class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        data-testid="annotation-add-button"
+      >
+        Add burst
+      </button>
+    </div>
+
+    {#if annotations.length > 0}
+      <div class="mt-4 space-y-3">
+        {#each Object.entries(grouped) as [waste, items] (waste)}
+          <section data-testid="waste-group-{waste}">
+            <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500">
+              {WASTE_TYPE_LABELS[waste]} ({items.length})
+            </h4>
+            <ul class="mt-1 space-y-1">
+              {#each items as a (a.id)}
+                <li
+                  class="flex items-center justify-between rounded border border-amber-200 bg-amber-50 px-2 py-1 text-xs"
+                  data-testid="annotation-{a.id}"
+                >
+                  <span>
+                    <span class="font-medium">{targetLabel(a)}</span>
+                    {#if a.note}<span class="text-gray-600"> — {a.note}</span>{/if}
+                  </span>
+                  <button
+                    type="button"
+                    onclick={() => vsmDataStore.removeAnnotation(a.id)}
+                    class="text-red-600 hover:text-red-800"
+                    aria-label="Remove annotation"
+                    data-testid="annotation-remove-{a.id}"
+                  >
+                    ✕
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</details>

--- a/src/data/wasteTypes.js
+++ b/src/data/wasteTypes.js
@@ -1,0 +1,29 @@
+/**
+ * Lean waste categories for Kaizen-burst annotations, adapted to software delivery.
+ * Used to tag improvement opportunities on steps and connections.
+ */
+export const WASTE_TYPES = {
+  WAITING: 'waiting',
+  HANDOFF: 'handoff',
+  REWORK: 'rework',
+  OVERPROCESSING: 'overprocessing',
+  OVERPRODUCTION: 'overproduction',
+  INVENTORY: 'inventory',
+  TASK_SWITCHING: 'task_switching',
+  PRACTICE_GAP: 'practice_gap',
+}
+
+/** Display labels for each waste type. */
+export const WASTE_TYPE_LABELS = {
+  [WASTE_TYPES.WAITING]: 'Waiting',
+  [WASTE_TYPES.HANDOFF]: 'Handoff',
+  [WASTE_TYPES.REWORK]: 'Rework / Defects',
+  [WASTE_TYPES.OVERPROCESSING]: 'Over-processing',
+  [WASTE_TYPES.OVERPRODUCTION]: 'Over-production',
+  [WASTE_TYPES.INVENTORY]: 'Inventory / WIP',
+  [WASTE_TYPES.TASK_SWITCHING]: 'Task switching',
+  [WASTE_TYPES.PRACTICE_GAP]: 'Practice gap',
+}
+
+/** True when the value is a recognized waste type. */
+export const isWasteType = (value) => Object.values(WASTE_TYPES).includes(value)

--- a/src/infrastructure/VsmJsonRepository.js
+++ b/src/infrastructure/VsmJsonRepository.js
@@ -17,9 +17,19 @@
  * @returns {string} JSON string representation
  */
 export function serializeVsm(vsm) {
-  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides } = vsm
+  const {
+    id,
+    name,
+    description,
+    steps,
+    connections,
+    createdAt,
+    updatedAt,
+    readinessOverrides,
+    annotations,
+  } = vsm
   return JSON.stringify(
-    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides },
+    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, annotations },
     null,
     2
   )
@@ -70,5 +80,6 @@ export function deserializeVsm(jsonString) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    annotations: Array.isArray(data.annotations) ? data.annotations : undefined,
   }
 }

--- a/src/stores/vsmDataStore.svelte.js
+++ b/src/stores/vsmDataStore.svelte.js
@@ -9,6 +9,7 @@ import { createStep } from '../models/StepFactory.js'
 import { createConnection } from '../models/ConnectionFactory.js'
 import { calculateMetrics } from '../utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../utils/calculations/cdReadiness.js'
+import { createAnnotation } from '../utils/annotations.js'
 import { sanitizeVSMData, validateVSMData } from '../utils/validation/vsmValidator.js'
 import { autoPositionStep } from '../utils/ui/autoPositionStep.js'
 import { vsmLocalStorageRepo } from '../infrastructure/VsmLocalStorageRepository.js'
@@ -34,6 +35,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
     createdAt: null,
     updatedAt: null,
     readinessOverrides: {},
+    annotations: [],
   }
 
   // Load persisted state; sanitize on read and validate to catch corrupted localStorage
@@ -51,6 +53,8 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
   let updatedAt = $state(persisted.updatedAt)
   // User confirm/override decisions for the CD readiness scorecard, keyed by item id
   let readinessOverrides = $state(persisted.readinessOverrides || {})
+  // Kaizen-burst improvement annotations for this map
+  let annotations = $state(persisted.annotations || [])
 
   // Cached metrics — only recomputed when steps or connections change
   let cachedMetrics = $derived(calculateMetrics(steps, connections))
@@ -71,6 +75,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt,
       updatedAt,
       readinessOverrides,
+      annotations,
     })
   }
 
@@ -113,6 +118,11 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       return readinessOverrides
     },
 
+    // Kaizen-burst improvement annotations
+    get annotations() {
+      return [...annotations]
+    },
+
     // Map-level Actions
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -124,6 +134,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      annotations = []
       persist()
     },
 
@@ -153,6 +164,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = safe.createdAt
       updatedAt = safe.updatedAt
       readinessOverrides = safe.readinessOverrides || {}
+      annotations = safe.annotations || []
       persist()
     },
 
@@ -165,6 +177,28 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      annotations = []
+      persist()
+    },
+
+    // Kaizen-burst annotation CRUD (per-map improvement backlog)
+    addAnnotation(targetType, targetId, wasteType, note = '') {
+      const annotation = createAnnotation(targetType, targetId, wasteType, note)
+      annotations = [...annotations, annotation]
+      updatedAt = new Date().toISOString()
+      persist()
+      return annotation
+    },
+
+    updateAnnotation(annotationId, updates) {
+      annotations = annotations.map((a) => (a.id === annotationId ? { ...a, ...updates } : a))
+      updatedAt = new Date().toISOString()
+      persist()
+    },
+
+    removeAnnotation(annotationId) {
+      annotations = annotations.filter((a) => a.id !== annotationId)
+      updatedAt = new Date().toISOString()
       persist()
     },
 
@@ -205,9 +239,18 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
     },
 
     deleteStep(stepId) {
+      const removedConnectionIds = connections
+        .filter((conn) => conn.source === stepId || conn.target === stepId)
+        .map((conn) => conn.id)
       steps = steps.filter((step) => step.id !== stepId)
       connections = connections.filter(
         (conn) => conn.source !== stepId && conn.target !== stepId
+      )
+      // Prune annotations targeting the removed step or its connections
+      annotations = annotations.filter(
+        (a) =>
+          !(a.targetType === 'step' && a.targetId === stepId) &&
+          !(a.targetType === 'connection' && removedConnectionIds.includes(a.targetId))
       )
       updatedAt = new Date().toISOString()
       persist()
@@ -245,6 +288,9 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
 
     deleteConnection(connectionId) {
       connections = connections.filter((conn) => conn.id !== connectionId)
+      annotations = annotations.filter(
+        (a) => !(a.targetType === 'connection' && a.targetId === connectionId)
+      )
       updatedAt = new Date().toISOString()
       persist()
     },

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -112,6 +112,7 @@ function createVsmIOStore() {
         createdAt: vsmDataStore.createdAt,
         updatedAt: vsmDataStore.updatedAt,
         readinessOverrides: vsmDataStore.readinessOverrides,
+        annotations: vsmDataStore.annotations,
       })
     },
 

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -1,0 +1,54 @@
+/**
+ * Kaizen-burst annotations
+ *
+ * Pure helpers for tagging improvement opportunities ("kaizen bursts") on steps
+ * and connections, then rolling them up into an improvement backlog grouped by
+ * waste type.
+ */
+
+import { WASTE_TYPES, isWasteType } from '../data/wasteTypes.js'
+
+/**
+ * Create a kaizen annotation.
+ * @param {'step'|'connection'} targetType
+ * @param {string} targetId
+ * @param {string} wasteType - One of WASTE_TYPES (unrecognized → practice_gap)
+ * @param {string} [note]
+ * @returns {{id:string, targetType:string, targetId:string, wasteType:string, note:string, createdAt:string}}
+ */
+export function createAnnotation(targetType, targetId, wasteType, note = '') {
+  return {
+    id: crypto.randomUUID(),
+    targetType,
+    targetId,
+    wasteType: isWasteType(wasteType) ? wasteType : WASTE_TYPES.PRACTICE_GAP,
+    note,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * Group annotations by waste type.
+ * @param {Array} annotations
+ * @returns {Object} waste type -> annotation[]
+ */
+export function groupAnnotationsByWaste(annotations = []) {
+  return annotations.reduce((acc, a) => {
+    if (!acc[a.wasteType]) acc[a.wasteType] = []
+    acc[a.wasteType].push(a)
+    return acc
+  }, {})
+}
+
+/**
+ * Summarize the improvement backlog.
+ * @param {Array} annotations
+ * @returns {{total:number, byWaste:Object}}
+ */
+export function summarizeAnnotations(annotations = []) {
+  const byWaste = annotations.reduce((acc, a) => {
+    acc[a.wasteType] = (acc[a.wasteType] || 0) + 1
+    return acc
+  }, {})
+  return { total: annotations.length, byWaste }
+}

--- a/src/utils/validation/vsmValidator.js
+++ b/src/utils/validation/vsmValidator.js
@@ -128,5 +128,6 @@ export function sanitizeVSMData(data) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    annotations: Array.isArray(data.annotations) ? data.annotations : undefined,
   }
 }

--- a/tests/unit/utils/annotations.test.js
+++ b/tests/unit/utils/annotations.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createAnnotation,
+  groupAnnotationsByWaste,
+  summarizeAnnotations,
+} from '../../../src/utils/annotations'
+import { WASTE_TYPES } from '../../../src/data/wasteTypes'
+
+describe('createAnnotation', () => {
+  it('builds an annotation with an id and the given fields', () => {
+    const a = createAnnotation('step', 's1', WASTE_TYPES.WAITING, 'Long queue here')
+    expect(a.id).toBeTruthy()
+    expect(a.targetType).toBe('step')
+    expect(a.targetId).toBe('s1')
+    expect(a.wasteType).toBe(WASTE_TYPES.WAITING)
+    expect(a.note).toBe('Long queue here')
+    expect(a.createdAt).toBeTruthy()
+  })
+
+  it('defaults an unrecognized waste type to practice_gap', () => {
+    const a = createAnnotation('step', 's1', 'nonsense', '')
+    expect(a.wasteType).toBe(WASTE_TYPES.PRACTICE_GAP)
+  })
+})
+
+describe('groupAnnotationsByWaste', () => {
+  it('groups annotations by their waste type', () => {
+    const annotations = [
+      createAnnotation('step', 's1', WASTE_TYPES.WAITING, 'a'),
+      createAnnotation('step', 's2', WASTE_TYPES.WAITING, 'b'),
+      createAnnotation('connection', 'c1', WASTE_TYPES.REWORK, 'c'),
+    ]
+    const grouped = groupAnnotationsByWaste(annotations)
+    expect(grouped[WASTE_TYPES.WAITING]).toHaveLength(2)
+    expect(grouped[WASTE_TYPES.REWORK]).toHaveLength(1)
+    expect(grouped[WASTE_TYPES.HANDOFF]).toBeUndefined()
+  })
+})
+
+describe('summarizeAnnotations', () => {
+  it('counts total annotations and distinct waste types', () => {
+    const annotations = [
+      createAnnotation('step', 's1', WASTE_TYPES.WAITING, 'a'),
+      createAnnotation('step', 's2', WASTE_TYPES.WAITING, 'b'),
+      createAnnotation('connection', 'c1', WASTE_TYPES.REWORK, 'c'),
+    ]
+    const summary = summarizeAnnotations(annotations)
+    expect(summary.total).toBe(3)
+    expect(summary.byWaste[WASTE_TYPES.WAITING]).toBe(2)
+    expect(summary.byWaste[WASTE_TYPES.REWORK]).toBe(1)
+  })
+
+  it('handles an empty backlog', () => {
+    expect(summarizeAnnotations([])).toEqual({ total: 0, byWaste: {} })
+  })
+})


### PR DESCRIPTION
## What

Adds **Kaizen-burst problem annotations** from the roadmap. Facilitators tag improvement opportunities — a waste type plus a note — on steps and connections, and the map rolls them up into a **prioritized improvement backlog** grouped by waste type.

- 8 lean waste categories adapted to software delivery (waiting, handoff, rework, over-processing, over-production, inventory/WIP, task-switching, practice-gap).
- Backlog grouped by waste with per-item remove and a total summary.
- Annotations are **pruned automatically** when their target step/connection is deleted (no orphans).

## How

- `src/data/wasteTypes.js` + pure `src/utils/annotations.js` (`createAnnotation`, `groupAnnotationsByWaste`, `summarizeAnnotations`).
- Persisted per-map `annotations` array threaded through `vsmDataStore` (add/update/remove + delete-pruning), `sanitizeVSMData`, the JSON repository, and the cucumber test double — survives save/load and import/export.
- `src/components/metrics/AnnotationsPanel.svelte` — add form + grouped backlog.

## Tests

- 5 unit tests (create/default/group/summarize).
- 5 acceptance scenarios incl. roll-up, delete-pruning, and persistence (`features/builder/kaizen-annotations.feature`).
- Gate green: 432 unit tests, build, lint.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_