### PR TITLE
Add constraint → countermeasure recommendations (P2)

### DIFF
--- a/features/step-definitions/recommendations.steps.js
+++ b/features/step-definitions/recommendations.steps.js
@@ -1,0 +1,44 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { generateRecommendations } from '../../src/utils/calculations/recommendations.js'
+
+const recs = () =>
+  generateRecommendations(vsmDataStore.cdReadiness, vsmDataStore.metrics.bottleneckIds)
+
+const recById = (id) => recs().find((r) => r.id === id)
+
+Given('a healthy value stream with an automated deployment', function () {
+  this.vsm.createVSM('Healthy Map')
+  this.vsm.addStep('Development', {
+    type: 'development',
+    processTime: 120,
+    leadTime: 360,
+    percentCompleteAccurate: 100,
+  })
+  this.vsm.addStep('Deploy', { type: 'deployment', processTime: 60, leadTime: 180, automated: true })
+})
+
+When('I view the recommendations', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+Then('there are no recommendations', function () {
+  expect(recs()).to.have.lengthOf(0)
+})
+
+Then('there is a recommendation for {string}', function (id) {
+  expect(recById(id)).to.exist
+})
+
+Then('the recommendation for {string} deep-links to the practice guide', function (id) {
+  expect(recById(id).link).to.match(/beyond\.minimumcd\.org/)
+})
+
+Then('the first recommendation is for {string}', function (id) {
+  expect(recs()[0].id).to.equal(id)
+})
+
+Then('the recommendation for {string} is marked as a constraint', function (id) {
+  expect(recById(id).priority).to.equal('high')
+})

--- a/features/visualization/recommendations.feature
+++ b/features/visualization/recommendations.feature
@@ -1,0 +1,27 @@
+Feature: Constraint Recommendations
+  As a team facilitator
+  I want prescriptive countermeasures for the problems in my value stream
+  So that I know what to improve first
+
+  Scenario: A healthy stream yields no recommendations
+    Given a healthy value stream with an automated deployment
+    When I view the recommendations
+    Then there are no recommendations
+
+  Scenario: A long lead time produces a work-decomposition countermeasure
+    Given a value stream with steps:
+      | name        | processTime | leadTime |
+      | Development  | 120         | 1200     |
+    When I view the recommendations
+    Then there is a recommendation for "work-decomposition"
+    And the recommendation for "work-decomposition" deep-links to the practice guide
+
+  Scenario: The constraint is recommended first
+    Given a value stream with steps:
+      | name   | processTime | leadTime | queueSize |
+      | Intake | 30          | 1200     | 2         |
+      | Build  | 60          | 240      | 2         |
+      | Review | 30          | 480      | 25        |
+    When I view the recommendations
+    Then the first recommendation is for "wip-limits"
+    And the recommendation for "wip-limits" is marked as a constraint

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import RecommendationsPanel from './components/metrics/RecommendationsPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <RecommendationsPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/RecommendationsPanel.svelte
+++ b/src/components/metrics/RecommendationsPanel.svelte
@@ -1,0 +1,68 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { generateRecommendations } from '../../utils/calculations/recommendations.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let readiness = $derived(vsmDataStore.cdReadiness)
+  let bottleneckIds = $derived(vsmDataStore.metrics.bottleneckIds)
+  let recommendations = $derived(generateRecommendations(readiness, bottleneckIds))
+
+  const priorityColors = {
+    high: 'bg-red-100 text-red-800',
+    medium: 'bg-amber-100 text-amber-800',
+    low: 'bg-gray-100 text-gray-700',
+  }
+
+  function stepName(id) {
+    return steps.find((s) => s.id === id)?.name
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="recommendations-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Recommendations
+    {#if recommendations.length > 0}
+      <span class="ml-2 text-xs font-normal text-gray-500" data-testid="recommendations-summary">
+        {recommendations.length} to act on
+      </span>
+    {/if}
+  </summary>
+
+  {#if recommendations.length === 0}
+    <p class="mt-3 text-sm text-gray-500">
+      No constraints detected — add steps or resolve readiness gaps to see recommendations.
+    </p>
+  {:else}
+    <ul class="mt-3 space-y-2">
+      {#each recommendations as rec (rec.id)}
+        <li
+          class="rounded-md border border-gray-200 p-3"
+          data-testid="recommendation-{rec.id}"
+          data-priority={rec.priority}
+        >
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-medium text-gray-800">{rec.title}</span>
+            <span
+              class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase {priorityColors[rec.priority]}"
+            >
+              {rec.priority === 'high' ? 'constraint' : rec.priority}
+            </span>
+          </div>
+          <p class="mt-1 text-xs text-gray-600">{rec.finding}</p>
+          <p class="mt-1 text-xs font-medium text-gray-800">→ {rec.countermeasure}</p>
+          {#if rec.targetStepId && stepName(rec.targetStepId)}
+            <p class="mt-1 text-xs text-gray-500">Step: {stepName(rec.targetStepId)}</p>
+          {/if}
+          <a
+            href={rec.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mt-1 inline-block text-xs underline text-blue-600 hover:text-blue-800"
+          >
+            Learn more
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</details>

--- a/src/utils/calculations/recommendations.js
+++ b/src/utils/calculations/recommendations.js
@@ -1,0 +1,57 @@
+/**
+ * Constraint → countermeasure recommendations (P2)
+ *
+ * Turns detected CD-readiness gaps into prescriptive, deep-linked countermeasures,
+ * prioritizing the gaps that sit on the flow constraint (Theory of Constraints:
+ * fix the bottleneck first).
+ *
+ * Iterative framing — recommendations point at practices/constraints, never a
+ * single migration phase (beyond.minimumcd.org phases run simultaneously).
+ *
+ * Pure function. Consumes the output of calculateCdReadiness, so the inference
+ * logic is not duplicated here.
+ */
+
+/** Prescriptive countermeasure per readiness item id. */
+const COUNTERMEASURES = {
+  'work-decomposition': 'Slice work so each item completes within two days; integrate sooner.',
+  'testing-fundamentals':
+    'Re-architect the test suite to run in under 10 minutes — parallelize and replace slow dependencies.',
+  'wip-limits': 'Set an explicit WIP limit on this step so it acts as a flow governor.',
+  'small-batches': 'Reduce batch size; integrate and release smaller increments.',
+  'single-path-to-production':
+    'Automate one path to production and remove manual or duplicate deployment steps.',
+  'continuous-integration': 'Integrate to trunk at least daily behind automated tests.',
+  'definition-of-deployable':
+    'Define automated "definition of deployable" criteria so work does not bounce back.',
+  rollback: 'Add an automated rollback path that recovers production within minutes.',
+}
+
+const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 }
+
+/**
+ * Generate prioritized countermeasure recommendations from readiness gaps.
+ * @param {Array} readinessItems - Output of calculateCdReadiness
+ * @param {string[]} [bottleneckStepIds] - Step ids flagged as the constraint
+ * @returns {Array} Recommendations sorted constraint-first
+ */
+export function generateRecommendations(readinessItems = [], bottleneckStepIds = []) {
+  const onConstraint = new Set(bottleneckStepIds)
+
+  const recs = readinessItems
+    .filter((item) => item.status === 'gap' && COUNTERMEASURES[item.id])
+    .map((item) => ({
+      id: item.id,
+      title: item.label,
+      finding: item.explanation,
+      countermeasure: COUNTERMEASURES[item.id],
+      link: item.link,
+      targetStepId: item.stepId ?? null,
+      priority: item.stepId && onConstraint.has(item.stepId) ? 'high' : 'medium',
+    }))
+
+  return recs.sort((a, b) => {
+    const byPriority = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]
+    return byPriority !== 0 ? byPriority : a.title.localeCompare(b.title)
+  })
+}

--- a/tests/unit/calculations/recommendations.test.js
+++ b/tests/unit/calculations/recommendations.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { generateRecommendations } from '../../../src/utils/calculations/recommendations'
+
+const item = (o) => ({
+  id: 'work-decomposition',
+  label: 'Work Decomposition',
+  kind: 'signal',
+  status: 'gap',
+  stepId: 's1',
+  explanation: 'too big',
+  link: 'https://beyond.minimumcd.org/x',
+  ...o,
+})
+
+describe('generateRecommendations', () => {
+  it('returns no recommendations when there are no gaps', () => {
+    const recs = generateRecommendations([item({ status: 'met' })], [])
+    expect(recs).toEqual([])
+  })
+
+  it('creates a deep-linked countermeasure for each gap', () => {
+    const recs = generateRecommendations([item()], [])
+    expect(recs).toHaveLength(1)
+    expect(recs[0].title).toBe('Work Decomposition')
+    expect(recs[0].countermeasure).toMatch(/two days|slice/i)
+    expect(recs[0].link).toMatch(/beyond\.minimumcd\.org/)
+    expect(recs[0].targetStepId).toBe('s1')
+  })
+
+  it('ignores items with no defined countermeasure (e.g. unknown ids)', () => {
+    const recs = generateRecommendations([item({ id: 'mystery', status: 'gap' })], [])
+    expect(recs).toEqual([])
+  })
+
+  it('prioritizes recommendations on the constraint (bottleneck) first', () => {
+    const recs = generateRecommendations(
+      [
+        item({ id: 'work-decomposition', label: 'Work Decomposition', stepId: 's1' }),
+        item({ id: 'wip-limits', label: 'Work In Progress Limits', stepId: 'bottleneck' }),
+      ],
+      ['bottleneck']
+    )
+    expect(recs[0].id).toBe('wip-limits')
+    expect(recs[0].priority).toBe('high')
+    expect(recs[1].priority).toBe('medium')
+  })
+
+  it('does not assign a single migration phase', () => {
+    const recs = generateRecommendations([item()], [])
+    const text = `${recs[0].finding} ${recs[0].countermeasure}`
+    expect(/phase \d/i.test(text)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Adds **P2 prescriptive recommendations**. Turns the CD-readiness *gaps* into deep-linked **countermeasures**, ranked **constraint-first** (Theory of Constraints — fix the bottleneck before non-constraints).

- A gap pinned to a bottleneck step is marked **constraint** (high priority) and sorted first.
- Each recommendation carries the finding, a prescriptive countermeasure, the pinned step, and a beyond.minimumcd.org deep link.
- Iterative framing: recommendations reference practices/constraints, **never** a single migration phase.

## How

- `src/utils/calculations/recommendations.js` — pure `generateRecommendations(readinessItems, bottleneckStepIds)`. **Consumes** `calculateCdReadiness` output + `metrics.bottleneckIds`, so no inference is duplicated.
- `src/components/metrics/RecommendationsPanel.svelte` — prioritized list, mounted below the scorecard. No new persisted state.

## Tests

- 5 unit tests (no-gap, countermeasure mapping, unknown-id skip, constraint-first ordering, no-phase framing).
- 3 acceptance scenarios incl. constraint-first prioritization (`features/visualization/recommendations.feature`).
- Gate green: 432 unit tests, build, lint.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_