### PR TITLE
Add WIP & batch-size levers via Little's Law (P2)

### DIFF
--- a/features/step-definitions/wipLevers.steps.js
+++ b/features/step-definitions/wipLevers.steps.js
@@ -1,0 +1,48 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import {
+  wipFromLittlesLaw,
+  projectBatchSizeChange,
+} from '../../src/utils/calculations/littlesLaw.js'
+import { calculateTotalLeadTime } from '../../src/utils/calculations/metrics.js'
+
+const stepByName = (name) => vsmDataStore.steps.find((s) => s.name === name)
+
+Given(
+  'a step {string} with process time {int}, lead time {int}, and batch size {int}',
+  function (name, pt, lt, batch) {
+    this.vsm.createVSM('Levers Map')
+    this.vsm.addStep(name, { processTime: pt, leadTime: lt, batchSize: batch })
+  }
+)
+
+When('the team throughput is {int} items per day', function (throughput) {
+  this.throughput = throughput
+})
+
+When('I project halving the batch size of {string}', function (name) {
+  const step = stepByName(name)
+  this.projection = projectBatchSizeChange(step, Math.ceil(step.batchSize / 2))
+})
+
+When('I project doubling the batch size of {string}', function (name) {
+  const step = stepByName(name)
+  this.projection = projectBatchSizeChange(step, step.batchSize * 2)
+})
+
+Then('the estimated work in progress is {int} items', function (items) {
+  const totalLead = calculateTotalLeadTime(vsmDataStore.steps)
+  expect(wipFromLittlesLaw(this.throughput, totalLead)).to.equal(items)
+})
+
+Then('the projected lead time for {string} is {int} minutes', function (_name, minutes) {
+  expect(this.projection.projectedLeadTime).to.equal(minutes)
+})
+
+Then(
+  'the projected lead time for {string} is greater than {int} minutes',
+  function (_name, minutes) {
+    expect(this.projection.projectedLeadTime).to.be.greaterThan(minutes)
+  }
+)

--- a/features/visualization/wip-batch-levers.feature
+++ b/features/visualization/wip-batch-levers.feature
@@ -1,0 +1,21 @@
+Feature: WIP and Batch-Size Levers
+  As a team facilitator
+  I want to apply Little's Law and project batch-size changes
+  So that I can reason about WIP and small batches as flow levers
+
+  Scenario: Estimate WIP from Little's Law
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 960      |
+    When the team throughput is 2 items per day
+    Then the estimated work in progress is 4 items
+
+  Scenario: Halving a step's batch size shortens its lead time
+    Given a step "Build" with process time 60, lead time 240, and batch size 4
+    When I project halving the batch size of "Build"
+    Then the projected lead time for "Build" is 150 minutes
+
+  Scenario: Growing a step's batch size lengthens its lead time
+    Given a step "Build" with process time 60, lead time 240, and batch size 4
+    When I project doubling the batch size of "Build"
+    Then the projected lead time for "Build" is greater than 240 minutes

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import WipLeversPanel from './components/metrics/WipLeversPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <WipLeversPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/WipLeversPanel.svelte
+++ b/src/components/metrics/WipLeversPanel.svelte
@@ -1,0 +1,73 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import {
+    wipFromLittlesLaw,
+    projectBatchSizeChange,
+  } from '../../utils/calculations/littlesLaw.js'
+  import { calculateTotalLeadTime, formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let throughputPerDay = $state(1)
+
+  let totalLeadTime = $derived(calculateTotalLeadTime(steps))
+  let totalWip = $derived(wipFromLittlesLaw(throughputPerDay, totalLeadTime))
+
+  // Project halving each step's batch size.
+  function halved(step) {
+    return projectBatchSizeChange(step, Math.max(1, Math.ceil((step.batchSize || 1) / 2)))
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="wip-levers-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">WIP &amp; Batch Levers</summary>
+
+  {#if steps.length === 0}
+    <p class="mt-3 text-sm text-gray-500">Add steps to explore WIP and batch-size levers.</p>
+  {:else}
+    <div class="mt-3 flex items-center gap-3">
+      <label class="text-xs font-medium text-gray-700">
+        Throughput (items/day)
+        <input
+          type="number"
+          min="0"
+          step="0.1"
+          bind:value={throughputPerDay}
+          class="ml-1 w-20 rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="throughput-input"
+        />
+      </label>
+      <span class="text-xs text-gray-600" data-testid="total-wip">
+        Little's Law WIP: <strong>{totalWip}</strong> items in progress
+      </span>
+    </div>
+
+    <table class="mt-3 w-full text-xs">
+      <thead class="text-left text-gray-500">
+        <tr>
+          <th class="py-1">Step</th>
+          <th class="py-1">Batch</th>
+          <th class="py-1">WIP</th>
+          <th class="py-1">Lead time</th>
+          <th class="py-1">Halve batch →</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each steps as step (step.id)}
+          <tr class="border-t border-gray-100" data-testid="lever-row-{step.id}">
+            <td class="py-1 font-medium">{step.name}</td>
+            <td class="py-1">{step.batchSize ?? 1}</td>
+            <td class="py-1">{wipFromLittlesLaw(throughputPerDay, step.leadTime)}</td>
+            <td class="py-1">{formatDuration(step.leadTime)}</td>
+            <td class="py-1 {halved(step).deltaMinutes < 0 ? 'text-green-700' : 'text-gray-600'}">
+              {formatDuration(halved(step).projectedLeadTime)}
+              ({halved(step).deltaPercent}%)
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <p class="mt-2 text-[11px] text-gray-400">
+      WIP = throughput × lead time (Little's Law). Batch projection assumes wait time scales with batch size.
+    </p>
+  {/if}
+</details>

--- a/src/utils/calculations/littlesLaw.js
+++ b/src/utils/calculations/littlesLaw.js
@@ -1,0 +1,51 @@
+/**
+ * WIP & batch-size levers via Little's Law (P2)
+ *
+ * Little's Law: WIP = throughput × lead time. Batch size is the primary lever:
+ * smaller batches shrink the queueing (wait) portion of lead time. These pure
+ * functions let the simulator/dashboard project "what if we halve the batch?".
+ *
+ * Durations in minutes; throughput in items per (work) day.
+ */
+
+const MINUTES_PER_WORK_DAY = 480
+
+/**
+ * Estimate work in progress from Little's Law.
+ * @param {number} throughputPerDay - Completed items per work day
+ * @param {number} leadTimeMinutes - Lead time per item (minutes)
+ * @param {number} [minutesPerDay]
+ * @returns {number} Items in progress
+ */
+export function wipFromLittlesLaw(throughputPerDay, leadTimeMinutes, minutesPerDay = MINUTES_PER_WORK_DAY) {
+  if (!throughputPerDay || throughputPerDay <= 0) return 0
+  const leadTimeDays = (leadTimeMinutes || 0) / minutesPerDay
+  return Number((throughputPerDay * leadTimeDays).toFixed(2))
+}
+
+/**
+ * Project the lead-time impact of changing a step's batch size.
+ *
+ * Model: lead time = process time + wait time. Wait time scales linearly with
+ * batch size (smaller batches queue less), so projectedWait = wait × (new/current).
+ *
+ * @param {{processTime:number, leadTime:number, batchSize:number}} step
+ * @param {number} newBatchSize
+ * @returns {{newBatchSize:number, currentLeadTime:number, projectedLeadTime:number, deltaMinutes:number, deltaPercent:number}}
+ */
+export function projectBatchSizeChange(step, newBatchSize) {
+  const processTime = step.processTime || 0
+  const currentLeadTime = step.leadTime || 0
+  const currentBatch = step.batchSize && step.batchSize > 0 ? step.batchSize : 1
+  const batch = Math.max(1, Math.floor(newBatchSize) || 1)
+
+  const waitTime = Math.max(0, currentLeadTime - processTime)
+  const projectedWait = waitTime * (batch / currentBatch)
+  const projectedLeadTime = Math.round(processTime + projectedWait)
+
+  const deltaMinutes = projectedLeadTime - currentLeadTime
+  const deltaPercent =
+    currentLeadTime > 0 ? Number(((deltaMinutes / currentLeadTime) * 100).toFixed(1)) : 0
+
+  return { newBatchSize: batch, currentLeadTime, projectedLeadTime, deltaMinutes, deltaPercent }
+}

--- a/tests/unit/calculations/littlesLaw.test.js
+++ b/tests/unit/calculations/littlesLaw.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  wipFromLittlesLaw,
+  projectBatchSizeChange,
+} from '../../../src/utils/calculations/littlesLaw'
+
+describe('wipFromLittlesLaw', () => {
+  it('computes WIP = throughput x lead time (in days)', () => {
+    // 2 items/day, lead time 2 work days (960 min) => 4 items in progress
+    expect(wipFromLittlesLaw(2, 960)).toBe(4)
+  })
+
+  it('returns 0 when throughput is missing', () => {
+    expect(wipFromLittlesLaw(null, 960)).toBe(0)
+  })
+})
+
+describe('projectBatchSizeChange', () => {
+  const step = { processTime: 60, leadTime: 240, batchSize: 4 }
+
+  it('shrinks the wait portion proportionally to the batch reduction', () => {
+    // wait = 180; halving batch (4 -> 2) halves wait to 90; lead = 60 + 90 = 150
+    const result = projectBatchSizeChange(step, 2)
+    expect(result.projectedLeadTime).toBe(150)
+    expect(result.deltaMinutes).toBe(-90)
+  })
+
+  it('reports the percent change', () => {
+    const result = projectBatchSizeChange(step, 2)
+    expect(result.deltaPercent).toBe(-37.5)
+  })
+
+  it('never drops below process time and clamps batch to at least 1', () => {
+    const result = projectBatchSizeChange({ processTime: 60, leadTime: 240, batchSize: 4 }, 0)
+    expect(result.newBatchSize).toBe(1)
+    expect(result.projectedLeadTime).toBeGreaterThanOrEqual(60)
+  })
+
+  it('increases lead time when batch size grows', () => {
+    const result = projectBatchSizeChange(step, 8)
+    expect(result.projectedLeadTime).toBeGreaterThan(step.leadTime)
+    expect(result.deltaMinutes).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What

Adds **P2 WIP & batch levers**. Makes WIP and small batches first-class flow levers:

- **Little's Law** — estimates work in progress (`WIP = throughput × lead time`) per step and overall from an observed throughput.
- **Batch-size projection** — "what if we halve the batch?" Smaller batches shrink the queueing (wait) portion of lead time; larger batches grow it.

## How

- `src/utils/calculations/littlesLaw.js` — pure `wipFromLittlesLaw` and `projectBatchSizeChange` (wait time scales linearly with batch size; clamps batch ≥ 1; floors at process time).
- `src/components/metrics/WipLeversPanel.svelte` — throughput input, per-step WIP, and a halve-batch projection column. No new persisted state.

## Tests

- 6 unit tests (WIP formula, batch shrink/grow, percent change, clamping).
- 3 acceptance scenarios (`features/visualization/wip-batch-levers.feature`).
- Gate green: 433 unit tests, build, lint.

> Note: the batch-size model is a deliberately simple linear approximation (documented in the panel); the Monte-Carlo PR adds variability-aware queueing for higher fidelity.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_