### PR TITLE
Add Monte-Carlo lead-time simulation (P3)

### DIFF
--- a/features/simulation/monte-carlo.feature
+++ b/features/simulation/monte-carlo.feature
@@ -1,0 +1,21 @@
+Feature: Monte-Carlo Lead Time
+  As a team facilitator
+  I want to simulate lead-time variability across many trials
+  So that I can see the realistic range of delivery times, not a single number
+
+  Scenario: Zero variability reproduces the deterministic lead time
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 240      |
+      | Test | 120      |
+    When I run a Monte-Carlo simulation with 0% variability
+    Then the P50 lead time is 360 minutes
+
+  Scenario: Variability widens the percentile spread
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 240      |
+      | Test | 120      |
+    When I run a Monte-Carlo simulation with 40% variability
+    Then the P95 lead time is at least the P50 lead time
+    And the simulation is reproducible for the same seed

--- a/features/step-definitions/monteCarlo.steps.js
+++ b/features/step-definitions/monteCarlo.steps.js
@@ -1,0 +1,23 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { runMonteCarlo } from '../../src/utils/simulation/monteCarlo.js'
+
+When('I run a Monte-Carlo simulation with {int}% variability', function (percent) {
+  this.mcOptions = { trials: 500, variability: percent / 100, seed: 7 }
+  this.mc = runMonteCarlo(vsmDataStore.steps, this.mcOptions)
+})
+
+Then('the P50 lead time is {int} minutes', function (minutes) {
+  expect(this.mc.p50).to.equal(minutes)
+})
+
+Then('the P95 lead time is at least the P50 lead time', function () {
+  expect(this.mc.p95).to.be.at.least(this.mc.p50)
+})
+
+Then('the simulation is reproducible for the same seed', function () {
+  const repeat = runMonteCarlo(vsmDataStore.steps, this.mcOptions)
+  expect(repeat.p95).to.equal(this.mc.p95)
+  expect(repeat.mean).to.equal(this.mc.mean)
+})

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import MonteCarloPanel from './components/metrics/MonteCarloPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <MonteCarloPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/MonteCarloPanel.svelte
+++ b/src/components/metrics/MonteCarloPanel.svelte
@@ -1,0 +1,85 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { runMonteCarlo } from '../../utils/simulation/monteCarlo.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+
+  let variability = $state(0.25)
+  let trials = $state(1000)
+  let result = $state(null)
+
+  function run() {
+    result = runMonteCarlo(steps, { trials, variability, seed: 1 })
+  }
+
+  // Re-run is explicit (button), so results don't churn while editing the map.
+  const percentiles = $derived(
+    result
+      ? [
+          { label: 'P50 (typical)', value: result.p50 },
+          { label: 'P85 (likely worst)', value: result.p85 },
+          { label: 'P95 (rare worst)', value: result.p95 },
+          { label: 'Mean', value: result.mean },
+        ]
+      : []
+  )
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="monte-carlo-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Monte-Carlo Lead Time
+  </summary>
+
+  {#if steps.length === 0}
+    <p class="mt-3 text-sm text-gray-500">Add steps to simulate lead-time variability.</p>
+  {:else}
+    <div class="mt-3 flex flex-wrap items-end gap-3">
+      <label class="text-xs font-medium text-gray-700">
+        Variability: {Math.round(variability * 100)}%
+        <input
+          type="range"
+          min="0"
+          max="0.6"
+          step="0.05"
+          bind:value={variability}
+          class="mt-1 block w-40"
+          data-testid="variability-input"
+        />
+      </label>
+      <label class="text-xs font-medium text-gray-700">
+        Trials
+        <input
+          type="number"
+          min="10"
+          step="100"
+          bind:value={trials}
+          class="ml-1 w-24 rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="trials-input"
+        />
+      </label>
+      <button
+        type="button"
+        onclick={run}
+        class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700"
+        data-testid="run-monte-carlo-button"
+      >
+        Run
+      </button>
+    </div>
+
+    {#if result}
+      <div class="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4" data-testid="monte-carlo-results">
+        {#each percentiles as p (p.label)}
+          <div class="rounded-md border border-gray-200 p-2 text-center">
+            <div class="text-[10px] uppercase tracking-wide text-gray-500">{p.label}</div>
+            <div class="text-sm font-bold text-gray-800">{formatDuration(p.value)}</div>
+          </div>
+        {/each}
+      </div>
+      <p class="mt-2 text-[11px] text-gray-400">
+        {trials} trials. The spread between P50 and P95 is the risk variability adds to your lead time.
+      </p>
+    {/if}
+  {/if}
+</details>

--- a/src/utils/simulation/monteCarlo.js
+++ b/src/utils/simulation/monteCarlo.js
@@ -1,0 +1,85 @@
+/**
+ * Monte-Carlo lead-time simulation (P3)
+ *
+ * Real value streams have variability: the same step takes different amounts of
+ * time on different items, and high utilization turns that variability into
+ * queues. This module samples each step's lead time across many trials to
+ * produce a *distribution* of total lead time (P50/P85/P95) rather than a single
+ * deterministic number.
+ *
+ * Uses a seeded RNG so results are reproducible and testable.
+ */
+
+/**
+ * Deterministic PRNG (mulberry32). Returns a function yielding floats in [0, 1).
+ * @param {number} seed
+ * @returns {() => number}
+ */
+export function createSeededRng(seed) {
+  let a = seed >>> 0
+  return function rng() {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * The percentile value of a numeric sample (nearest-rank on sorted ascending).
+ * @param {number[]} values
+ * @param {number} p - 0..100
+ * @returns {number}
+ */
+export function percentile(values, p) {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((x, y) => x - y)
+  const rank = Math.ceil((p / 100) * sorted.length)
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1))
+  return sorted[index]
+}
+
+/**
+ * Sample a step's lead time using a symmetric triangular distribution centred on
+ * the recorded lead time with half-width = leadTime * variability.
+ * Triangular = average of two uniforms, which concentrates mass near the centre.
+ */
+function sampleLeadTime(leadTime, variability, rng) {
+  if (variability <= 0) return leadTime
+  const triangular = (rng() + rng()) / 2 // 0..1, peak at 0.5
+  const factor = 1 + (triangular * 2 - 1) * variability
+  return Math.max(0, leadTime * factor)
+}
+
+/**
+ * Run a Monte-Carlo simulation of total lead time.
+ * @param {Array} steps
+ * @param {{trials?:number, variability?:number, seed?:number}} [options]
+ *   variability is a coefficient (0 = deterministic, 0.3 = ±30%).
+ * @returns {{samples:number[], p50:number, p85:number, p95:number, mean:number}}
+ */
+export function runMonteCarlo(steps = [], options = {}) {
+  const { trials = 1000, variability = 0.25, seed = 1 } = options
+  const rng = createSeededRng(seed)
+
+  const samples = []
+  for (let trial = 0; trial < trials; trial++) {
+    let total = 0
+    for (const step of steps) {
+      total += sampleLeadTime(step.leadTime || 0, variability, rng)
+    }
+    samples.push(Math.round(total))
+  }
+
+  const mean =
+    samples.length > 0 ? Math.round(samples.reduce((sum, v) => sum + v, 0) / samples.length) : 0
+
+  return {
+    samples,
+    p50: percentile(samples, 50),
+    p85: percentile(samples, 85),
+    p95: percentile(samples, 95),
+    mean,
+  }
+}

--- a/tests/unit/simulation/monteCarlo.test.js
+++ b/tests/unit/simulation/monteCarlo.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createSeededRng,
+  runMonteCarlo,
+  percentile,
+} from '../../../src/utils/simulation/monteCarlo'
+
+const steps = [
+  { id: 'a', name: 'A', processTime: 60, leadTime: 240 },
+  { id: 'b', name: 'B', processTime: 30, leadTime: 120 },
+]
+
+describe('createSeededRng', () => {
+  it('is deterministic for a given seed', () => {
+    const r1 = createSeededRng(42)
+    const r2 = createSeededRng(42)
+    expect(r1()).toBe(r2())
+    expect(r1()).toBe(r2())
+  })
+
+  it('produces values in [0, 1)', () => {
+    const rng = createSeededRng(7)
+    for (let i = 0; i < 100; i++) {
+      const v = rng()
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(1)
+    }
+  })
+})
+
+describe('percentile', () => {
+  it('returns the value at the requested percentile', () => {
+    expect(percentile([10, 20, 30, 40, 50], 50)).toBe(30)
+    expect(percentile([10, 20, 30, 40, 50], 100)).toBe(50)
+  })
+})
+
+describe('runMonteCarlo', () => {
+  it('returns the deterministic total when variability is zero', () => {
+    const result = runMonteCarlo(steps, { trials: 100, variability: 0, seed: 1 })
+    expect(result.p50).toBe(360)
+    expect(result.p85).toBe(360)
+    expect(result.mean).toBe(360)
+  })
+
+  it('produces an increasing percentile spread under variability', () => {
+    const result = runMonteCarlo(steps, { trials: 500, variability: 0.3, seed: 1 })
+    expect(result.p50).toBeLessThanOrEqual(result.p85)
+    expect(result.p85).toBeLessThanOrEqual(result.p95)
+    expect(result.samples).toHaveLength(500)
+  })
+
+  it('is reproducible for the same seed', () => {
+    const a = runMonteCarlo(steps, { trials: 200, variability: 0.4, seed: 99 })
+    const b = runMonteCarlo(steps, { trials: 200, variability: 0.4, seed: 99 })
+    expect(a.p85).toBe(b.p85)
+    expect(a.mean).toBe(b.mean)
+  })
+
+  it('handles an empty stream', () => {
+    const result = runMonteCarlo([], { trials: 10, variability: 0.2, seed: 1 })
+    expect(result.p50).toBe(0)
+    expect(result.samples).toHaveLength(10)
+  })
+})


### PR DESCRIPTION
## What

Adds **P3 Monte-Carlo variability**. Real value streams are variable — the same step takes different times on different items. Instead of one deterministic lead time, this samples across many trials to show the **distribution**: P50 (typical), P85 (likely worst), P95 (rare worst), and mean. The P50→P95 spread is the risk that variability adds.

## How

- `src/utils/simulation/monteCarlo.js` — seeded `mulberry32` RNG (reproducible/testable), symmetric triangular sampling around each step's lead time, a `percentile` helper, and `runMonteCarlo(steps, {trials, variability, seed})`.
- `src/components/metrics/MonteCarloPanel.svelte` — variability slider + trials, explicit Run, percentile result cards. No new persisted state.

## Tests

- 7 unit tests (RNG determinism + range, percentile, zero-variability = deterministic, increasing spread, reproducibility, empty stream).
- 2 acceptance scenarios (`features/simulation/monte-carlo.feature`).
- Gate green: 434 unit tests, build, lint.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_