### PR TITLE
Add current-state vs future-state comparison (P3)

### DIFF
--- a/features/builder/current-future-state.feature
+++ b/features/builder/current-future-state.feature
@@ -1,0 +1,25 @@
+Feature: Current vs Future State
+  As a team facilitator
+  I want to capture a baseline and compare an improved map against it
+  So that I can quantify the projected improvement of my future state
+
+  Background:
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 60          | 600      |
+
+  Scenario: No comparison until a baseline is captured
+    When I view the state comparison
+    Then there is no state comparison
+
+  Scenario: Reducing wait time shows an improved lead time
+    When I capture the current state as the baseline
+    And I reduce the lead time of "Dev" to 300
+    Then the future-state total lead time delta is -300 minutes
+    And the future-state total lead time is improved
+
+  Scenario: The captured baseline survives save and reload
+    When I capture the current state as the baseline
+    And I reduce the lead time of "Dev" to 300
+    And the map is saved and reloaded
+    Then the future-state total lead time delta is -300 minutes

--- a/features/step-definitions/futureState.steps.js
+++ b/features/step-definitions/futureState.steps.js
@@ -1,0 +1,38 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { compareStates } from '../../src/utils/calculations/futureState.js'
+
+const stepByName = (name) => vsmDataStore.steps.find((s) => s.name === name)
+
+const comparison = () =>
+  compareStates(
+    vsmDataStore.baseline?.steps ?? null,
+    vsmDataStore.baseline?.connections ?? [],
+    vsmDataStore.steps,
+    vsmDataStore.connections
+  )
+
+When('I view the state comparison', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+When('I capture the current state as the baseline', function () {
+  vsmDataStore.captureBaseline()
+})
+
+When('I reduce the lead time of {string} to {int}', function (name, leadTime) {
+  vsmDataStore.updateStep(stepByName(name).id, { leadTime })
+})
+
+Then('there is no state comparison', function () {
+  expect(comparison()).to.equal(null)
+})
+
+Then('the future-state total lead time delta is {int} minutes', function (delta) {
+  expect(comparison().deltas.totalLeadTime.delta).to.equal(delta)
+})
+
+Then('the future-state total lead time is improved', function () {
+  expect(comparison().deltas.totalLeadTime.improved).to.equal(true)
+})

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -23,6 +23,7 @@ function createTestVsmDataStore() {
   let createdAt = null
   let updatedAt = null
   let readinessOverrides = {}
+  let baseline = null
 
   return {
     get id() {
@@ -55,6 +56,19 @@ function createTestVsmDataStore() {
     get readinessOverrides() {
       return readinessOverrides
     },
+    get baseline() {
+      return baseline
+    },
+    captureBaseline() {
+      baseline = {
+        steps: steps.map((s) => ({ ...s })),
+        connections: connections.map((c) => ({ ...c })),
+        capturedAt: new Date().toISOString(),
+      }
+    },
+    clearBaseline() {
+      baseline = null
+    },
 
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -66,6 +80,7 @@ function createTestVsmDataStore() {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      baseline = null
     },
 
     setReadinessOverride(itemId, status) {
@@ -101,6 +116,7 @@ function createTestVsmDataStore() {
       createdAt = mapData.createdAt
       updatedAt = mapData.updatedAt
       readinessOverrides = mapData.readinessOverrides || {}
+      baseline = mapData.baseline || null
     },
 
     clearMap() {
@@ -112,6 +128,7 @@ function createTestVsmDataStore() {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      baseline = null
     },
 
     addStep(stepName = 'New Step', overrides = {}) {
@@ -310,6 +327,7 @@ function createTestVsmIOStore(dataStore) {
         createdAt: dataStore.createdAt,
         updatedAt: dataStore.updatedAt,
         readinessOverrides: dataStore.readinessOverrides,
+        baseline: dataStore.baseline,
       })
     },
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import FutureStatePanel from './components/metrics/FutureStatePanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <FutureStatePanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/FutureStatePanel.svelte
+++ b/src/components/metrics/FutureStatePanel.svelte
@@ -1,0 +1,79 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { compareStates } from '../../utils/calculations/futureState.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let connections = $derived(vsmDataStore.connections)
+  let baseline = $derived(vsmDataStore.baseline)
+
+  let comparison = $derived(
+    compareStates(baseline?.steps ?? null, baseline?.connections ?? [], steps, connections)
+  )
+
+  const rows = [
+    { key: 'totalLeadTime', label: 'Total lead time', fmt: formatDuration },
+    { key: 'totalProcessTime', label: 'Total process time', fmt: formatDuration },
+    { key: 'flowEfficiency', label: 'Flow efficiency', fmt: (v) => `${v.toFixed(1)}%` },
+    { key: 'firstPassYield', label: 'First pass yield', fmt: (v) => `${v.toFixed(1)}%` },
+  ]
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="future-state-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Current vs Future State
+  </summary>
+
+  <div class="mt-3 flex gap-2">
+    <button
+      type="button"
+      onclick={() => vsmDataStore.captureBaseline()}
+      class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700"
+      data-testid="capture-baseline-button"
+      disabled={steps.length === 0}
+    >
+      {baseline ? 'Re-capture baseline' : 'Capture current as baseline'}
+    </button>
+    {#if baseline}
+      <button
+        type="button"
+        onclick={() => vsmDataStore.clearBaseline()}
+        class="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+        data-testid="clear-baseline-button"
+      >
+        Clear
+      </button>
+    {/if}
+  </div>
+
+  {#if !comparison}
+    <p class="mt-3 text-sm text-gray-500">
+      Capture the current state as a baseline, then improve the map to see the projected deltas.
+    </p>
+  {:else}
+    <table class="mt-3 w-full text-xs" data-testid="state-comparison">
+      <thead class="text-left text-gray-500">
+        <tr>
+          <th class="py-1">Metric</th>
+          <th class="py-1">Baseline</th>
+          <th class="py-1">Working</th>
+          <th class="py-1">Delta</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row (row.key)}
+          {@const d = comparison.deltas[row.key]}
+          <tr class="border-t border-gray-100" data-testid="comparison-row-{row.key}" data-improved={d.improved}>
+            <td class="py-1 font-medium">{row.label}</td>
+            <td class="py-1">{row.fmt(d.baseline)}</td>
+            <td class="py-1">{row.fmt(d.working)}</td>
+            <td class="py-1 {d.improved ? 'text-green-700' : d.delta === 0 ? 'text-gray-500' : 'text-red-700'}">
+              {d.delta > 0 ? '+' : ''}{row.fmt(d.delta)}
+              {#if d.improved}<span class="ml-1">↓ improved</span>{/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</details>

--- a/src/infrastructure/VsmJsonRepository.js
+++ b/src/infrastructure/VsmJsonRepository.js
@@ -17,9 +17,19 @@
  * @returns {string} JSON string representation
  */
 export function serializeVsm(vsm) {
-  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides } = vsm
+  const {
+    id,
+    name,
+    description,
+    steps,
+    connections,
+    createdAt,
+    updatedAt,
+    readinessOverrides,
+    baseline,
+  } = vsm
   return JSON.stringify(
-    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides },
+    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, baseline },
     null,
     2
   )
@@ -70,5 +80,6 @@ export function deserializeVsm(jsonString) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    baseline: data.baseline && typeof data.baseline === 'object' ? data.baseline : undefined,
   }
 }

--- a/src/stores/vsmDataStore.svelte.js
+++ b/src/stores/vsmDataStore.svelte.js
@@ -51,6 +51,8 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
   let updatedAt = $state(persisted.updatedAt)
   // User confirm/override decisions for the CD readiness scorecard, keyed by item id
   let readinessOverrides = $state(persisted.readinessOverrides || {})
+  // Captured baseline (current-state) snapshot for future-state comparison
+  let baseline = $state(persisted.baseline || null)
 
   // Cached metrics — only recomputed when steps or connections change
   let cachedMetrics = $derived(calculateMetrics(steps, connections))
@@ -71,6 +73,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt,
       updatedAt,
       readinessOverrides,
+      baseline,
     })
   }
 
@@ -113,6 +116,11 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       return readinessOverrides
     },
 
+    // Captured baseline snapshot for current-vs-future-state comparison
+    get baseline() {
+      return baseline
+    },
+
     // Map-level Actions
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -124,6 +132,22 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      baseline = null
+      persist()
+    },
+
+    // Capture the live map as the baseline (current state) for comparison
+    captureBaseline() {
+      baseline = {
+        steps: steps.map((s) => ({ ...s })),
+        connections: connections.map((c) => ({ ...c })),
+        capturedAt: new Date().toISOString(),
+      }
+      persist()
+    },
+
+    clearBaseline() {
+      baseline = null
       persist()
     },
 
@@ -153,6 +177,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = safe.createdAt
       updatedAt = safe.updatedAt
       readinessOverrides = safe.readinessOverrides || {}
+      baseline = safe.baseline || null
       persist()
     },
 
@@ -165,6 +190,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      baseline = null
       persist()
     },
 

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -112,6 +112,7 @@ function createVsmIOStore() {
         createdAt: vsmDataStore.createdAt,
         updatedAt: vsmDataStore.updatedAt,
         readinessOverrides: vsmDataStore.readinessOverrides,
+        baseline: vsmDataStore.baseline,
       })
     },
 

--- a/src/utils/calculations/futureState.js
+++ b/src/utils/calculations/futureState.js
@@ -1,0 +1,53 @@
+/**
+ * Current-state vs future-state comparison (P3)
+ *
+ * The classic VSM workflow draws a current state, designs an improved future
+ * state, and quantifies the projected improvement. This app captures a baseline
+ * snapshot; the live ("working") map is then improved and compared against it.
+ *
+ * Pure function. Reuses calculateMetrics so the metric definitions are shared.
+ */
+
+import { calculateMetrics } from './metrics.js'
+
+// For each metric: does a higher value mean improvement?
+const HIGHER_IS_BETTER = {
+  totalLeadTime: false,
+  totalProcessTime: false,
+  flowEfficiency: true,
+  firstPassYield: true,
+}
+
+const summarize = (steps, connections) => {
+  const m = calculateMetrics(steps, connections)
+  return {
+    totalLeadTime: m.totalLeadTime,
+    totalProcessTime: m.totalProcessTime,
+    flowEfficiency: m.flowEfficiency.percentage,
+    firstPassYield: m.firstPassYield.percentage,
+  }
+}
+
+const delta = (metric, base, work) => {
+  const d = Number((work - base).toFixed(2))
+  const improved = d === 0 ? false : HIGHER_IS_BETTER[metric] ? d > 0 : d < 0
+  return { baseline: base, working: work, delta: d, improved }
+}
+
+/**
+ * Compare a baseline state against a working state.
+ * @returns {Object|null} null when there is no baseline to compare against
+ */
+export function compareStates(baselineSteps, baselineConnections, workingSteps, workingConnections) {
+  if (!baselineSteps) return null
+
+  const baseline = summarize(baselineSteps, baselineConnections || [])
+  const working = summarize(workingSteps || [], workingConnections || [])
+
+  const deltas = Object.keys(HIGHER_IS_BETTER).reduce((acc, metric) => {
+    acc[metric] = delta(metric, baseline[metric], working[metric])
+    return acc
+  }, {})
+
+  return { baseline, working, deltas }
+}

--- a/src/utils/validation/vsmValidator.js
+++ b/src/utils/validation/vsmValidator.js
@@ -128,5 +128,7 @@ export function sanitizeVSMData(data) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    baseline:
+      data.baseline && typeof data.baseline === 'object' ? data.baseline : undefined,
   }
 }

--- a/tests/unit/calculations/futureState.test.js
+++ b/tests/unit/calculations/futureState.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { compareStates } from '../../../src/utils/calculations/futureState'
+
+const baseline = [
+  { id: 'a', name: 'Dev', processTime: 60, leadTime: 600, percentCompleteAccurate: 80 },
+]
+// Working state: same work, less waiting (lead time halved)
+const working = [
+  { id: 'a', name: 'Dev', processTime: 60, leadTime: 300, percentCompleteAccurate: 80 },
+]
+
+describe('compareStates', () => {
+  it('reports baseline and working metrics side by side', () => {
+    const result = compareStates(baseline, [], working, [])
+    expect(result.baseline.totalLeadTime).toBe(600)
+    expect(result.working.totalLeadTime).toBe(300)
+  })
+
+  it('computes the lead-time delta and improvement direction', () => {
+    const result = compareStates(baseline, [], working, [])
+    expect(result.deltas.totalLeadTime.delta).toBe(-300)
+    expect(result.deltas.totalLeadTime.improved).toBe(true)
+  })
+
+  it('marks flow efficiency as improved when it rises', () => {
+    const result = compareStates(baseline, [], working, [])
+    // base efficiency 60/600 = 10%, working 60/300 = 20%
+    expect(result.deltas.flowEfficiency.delta).toBeGreaterThan(0)
+    expect(result.deltas.flowEfficiency.improved).toBe(true)
+  })
+
+  it('reports no change when states are identical', () => {
+    const result = compareStates(baseline, [], baseline, [])
+    expect(result.deltas.totalLeadTime.delta).toBe(0)
+    expect(result.deltas.totalLeadTime.improved).toBe(false)
+  })
+
+  it('handles a missing baseline by returning null', () => {
+    expect(compareStates(null, null, working, [])).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Adds **P3 current-state vs future-state framing** — the classic two-state VSM workflow with projected deltas. Capture the live map as a **baseline**, improve it, and see the projected improvement for total lead time, total process time, flow efficiency, and first-pass yield, each with an improvement direction.

## How

- `src/utils/calculations/futureState.js` — pure `compareStates(...)` that **reuses `calculateMetrics`** for both states and computes per-metric deltas + `improved` (knows which metrics are higher-is-better).
- Persisted per-map `baseline` snapshot threaded through `vsmDataStore` (`captureBaseline`/`clearBaseline`), `sanitizeVSMData`, the JSON repository, and the cucumber test double — survives save/load and import/export.
- `src/components/metrics/FutureStatePanel.svelte` — capture/clear controls + baseline-vs-working delta table.

## Tests

- 5 unit tests (side-by-side metrics, lead-time delta + direction, flow-efficiency improvement, no-change, missing-baseline).
- 3 acceptance scenarios incl. persistence (`features/builder/current-future-state.feature`).
- Gate green: 432 unit tests, build, lint.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_