### PR TITLE
Integrate CD Readiness Diagnosis suite (P1a–P3, 7 features + import design)

### DIFF
--- a/docs/specs/real-tooling-import.md
+++ b/docs/specs/real-tooling-import.md
@@ -1,0 +1,127 @@
+# Design: Import Current-State from Real Tooling (P3)
+
+> **Status: design only.** This PR contains no runtime code. Live Jira/GitHub/CI
+> integration needs external systems and credentials that are not reachable in
+> the build sandbox, so it cannot ship as working, tested code here. This document
+> specifies the adapter interface and a file-based importer so the live adapters
+> can be added later behind a stable contract.
+
+## Intent
+
+Today every VSM is hand-entered, so the durations, queue sizes, and WIP are
+**guesses** — and guessed maps hide the real waste. The strongest "find the
+problem" upgrade is to derive the current state from **actual timestamps** in the
+tools teams already use (Jira/GitHub issues + PRs, CI pipelines). Importing real
+data turns the map from a drawing into a measurement, and it makes the existing
+diagnostics (CD readiness scorecard, wait-time waterfall, DORA reconciliation)
+trustworthy.
+
+This feature imports a **current-state value stream** from real tooling: it maps
+recorded state-transition timestamps onto VSM steps, deriving process time, lead
+time, queue size, and WIP from the data rather than from estimates.
+
+## Architecture
+
+### Pluggable import adapter (the stable contract)
+
+```js
+/**
+ * @typedef {Object} WorkItemEvent
+ * @property {string} workItemId   - Stable id of the issue/PR/build
+ * @property {string} stage        - The workflow stage entered (maps to a VSM step)
+ * @property {string} enteredAt    - ISO timestamp the item entered the stage
+ * @property {string} [exitedAt]   - ISO timestamp the item left the stage
+ * @property {boolean} [reentry]   - True when the item returned to an earlier stage (rework)
+ */
+
+/**
+ * @typedef {Object} ImportAdapter
+ * @property {string} id                                  - e.g. 'jira', 'github', 'ci', 'csv'
+ * @property {string} label
+ * @property {(raw: unknown) => WorkItemEvent[]} parse    - Normalize source data to events
+ */
+```
+
+Every source (live or file) is just an adapter that produces a flat list of
+**`WorkItemEvent`s**. The mapping from events → a VSM is source-agnostic, so the
+hard/diagnostic logic is written and tested once.
+
+### Source data → VSM derivation (pure, testable)
+
+`deriveVsmFromEvents(events, { stageOrder })` → `{ steps, connections }`:
+
+| VSM field | Derived from events |
+|---|---|
+| step `name` / order | distinct `stage` values, ordered by `stageOrder` (or first-seen) |
+| step `processTime` | median active time in stage (`exitedAt − enteredAt`) where the item was being worked |
+| step `leadTime` | median total time in stage including waiting (entry of stage → entry of next stage) |
+| step `queueSize` | mean count of items concurrently waiting to enter the stage (Little's-Law-consistent) |
+| step `percentCompleteAccurate` | `100 × (1 − reentryRate)` for the stage |
+| `connection` forward | consecutive stages in `stageOrder` |
+| `connection` rework | stage pairs where `reentry` events flow backward, `reworkRate` = share of items |
+
+Medians (not means) resist the long-tail outliers typical of delivery data.
+This module is **pure** and fully unit-testable with synthetic event fixtures —
+no network required — which is the whole point of the adapter boundary.
+
+### Concrete adapters
+
+1. **`csvImportAdapter` / `jsonImportAdapter` (ships first, fully testable).**
+   Accepts an exported event log (one row per work-item state transition:
+   `workItemId, stage, enteredAt, exitedAt`). This is the working stand-in:
+   teams can export from any tool and import a real current state today, with
+   zero credentials. It exercises the entire derivation pipeline.
+2. **`jiraImportAdapter` (later, needs API token + network).** Pulls issue
+   changelogs; maps status transitions → `WorkItemEvent`s.
+3. **`githubImportAdapter` (later).** Issues + PR review/merge timeline events.
+4. **`ciImportAdapter` (later).** Pipeline run timestamps per stage.
+
+The live adapters are **thin**: fetch + shape into `WorkItemEvent[]`. They add no
+new derivation logic, so they need only integration tests against recorded
+fixtures, and the diagnostic value lands with the file adapter first.
+
+### Integration points
+
+- New `src/utils/import/deriveVsm.js` (pure) + `src/utils/import/adapters/*`.
+- `vsmIOStore` gains `importCurrentState(adapterId, rawData)` → builds a map via
+  the adapter + `deriveVsmFromEvents`, then `loadMap(...)` (reusing the existing
+  load/persist path — no new persistence surface).
+- An "Import current state" entry in the IO UI, with a file picker for the
+  CSV/JSON adapter and (later) connection settings for the live adapters.
+- Imported maps set a provenance flag (`source: 'imported'`, `importedAt`) so the
+  UI can distinguish measured maps from hand-drawn ones.
+
+## Acceptance Criteria
+
+1. `deriveVsmFromEvents` builds an ordered set of steps from a synthetic event log
+   and derives processTime/leadTime/queueSize per step (median-based).
+2. Reentry events produce a rework connection with a `reworkRate` equal to the
+   share of items that returned, and reduce the stage's `%C&A`.
+3. The CSV/JSON adapter round-trips a sample export into a VSM that loads via
+   `loadMap` and is indistinguishable (shape-wise) from a hand-built map.
+4. Importing replaces the working map through the existing `loadMap` path and is
+   undoable / re-exportable like any map.
+5. Live adapters (Jira/GitHub/CI) conform to `ImportAdapter` and are covered by
+   fixture-based integration tests (no live calls in CI).
+6. Malformed/partial source rows are skipped with a surfaced warning rather than
+   corrupting the map.
+
+## Why design-only here
+
+The pure `deriveVsmFromEvents` engine and the CSV/JSON adapter **could** be built
+and tested in this sandbox today and would deliver real value (criteria 1–4, 6).
+They are split out only to keep this PR a reviewable contract; the live
+network adapters (criterion 5) are the part that genuinely cannot be exercised
+without external systems. Recommended next step: implement `deriveVsmFromEvents`
++ the file adapter as a normal feature PR, then add live adapters behind this
+interface when credentials/network are available.
+
+## Migration / sequencing
+
+1. **PR-A (feasible now):** pure `deriveVsmFromEvents` + `csv`/`json` adapters +
+   `importCurrentState` wiring + UI file picker. Full unit/acceptance coverage.
+2. **PR-B:** Jira adapter (token-gated, fixture tests).
+3. **PR-C:** GitHub adapter.
+4. **PR-D:** CI adapter.
+
+Each later PR is additive and changes no derivation logic.

--- a/features/builder/current-future-state.feature
+++ b/features/builder/current-future-state.feature
@@ -1,0 +1,25 @@
+Feature: Current vs Future State
+  As a team facilitator
+  I want to capture a baseline and compare an improved map against it
+  So that I can quantify the projected improvement of my future state
+
+  Background:
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 60          | 600      |
+
+  Scenario: No comparison until a baseline is captured
+    When I view the state comparison
+    Then there is no state comparison
+
+  Scenario: Reducing wait time shows an improved lead time
+    When I capture the current state as the baseline
+    And I reduce the lead time of "Dev" to 300
+    Then the future-state total lead time delta is -300 minutes
+    And the future-state total lead time is improved
+
+  Scenario: The captured baseline survives save and reload
+    When I capture the current state as the baseline
+    And I reduce the lead time of "Dev" to 300
+    And the map is saved and reloaded
+    Then the future-state total lead time delta is -300 minutes

--- a/features/builder/kaizen-annotations.feature
+++ b/features/builder/kaizen-annotations.feature
@@ -1,0 +1,37 @@
+Feature: Kaizen-Burst Annotations
+  As a team facilitator
+  I want to tag improvement opportunities on steps and edges
+  So that the value stream rolls up into a prioritized improvement backlog
+
+  Background:
+    Given a value stream with steps:
+      | name   | leadTime |
+      | Dev    | 240      |
+      | Review | 480      |
+
+  Scenario: Annotate a step with a waste type
+    When I annotate the "Review" step with "waiting" waste noted "Long approval queue"
+    Then the improvement backlog has 1 kaizen burst
+    And the backlog has 1 "waiting" annotation
+
+  Scenario: Roll up annotations by waste type
+    When I annotate the "Review" step with "waiting" waste noted "queue"
+    And I annotate the "Dev" step with "waiting" waste noted "blocked"
+    And I annotate the "Review" step with "rework" waste noted "bounces back"
+    Then the backlog has 2 "waiting" annotations
+    And the backlog has 1 "rework" annotation
+
+  Scenario: Remove an annotation from the backlog
+    When I annotate the "Review" step with "handoff" waste noted "manual"
+    And I remove that annotation
+    Then the improvement backlog has 0 kaizen bursts
+
+  Scenario: Deleting a step prunes its annotations
+    When I annotate the "Review" step with "waiting" waste noted "queue"
+    And I delete the "Review" step
+    Then the improvement backlog has 0 kaizen bursts
+
+  Scenario: Annotations survive save and reload
+    When I annotate the "Review" step with "waiting" waste noted "queue"
+    And the map is saved and reloaded
+    Then the improvement backlog has 1 kaizen burst

--- a/features/simulation/monte-carlo.feature
+++ b/features/simulation/monte-carlo.feature
@@ -1,0 +1,21 @@
+Feature: Monte-Carlo Lead Time
+  As a team facilitator
+  I want to simulate lead-time variability across many trials
+  So that I can see the realistic range of delivery times, not a single number
+
+  Scenario: Zero variability reproduces the deterministic lead time
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 240      |
+      | Test | 120      |
+    When I run a Monte-Carlo simulation with 0% variability
+    Then the P50 lead time is 360 minutes
+
+  Scenario: Variability widens the percentile spread
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 240      |
+      | Test | 120      |
+    When I run a Monte-Carlo simulation with 40% variability
+    Then the P95 lead time is at least the P50 lead time
+    And the simulation is reproducible for the same seed

--- a/features/step-definitions/dora.steps.js
+++ b/features/step-definitions/dora.steps.js
@@ -1,0 +1,37 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import {
+  reconcileLeadTime,
+  classifyDora,
+} from '../../src/utils/calculations/doraReconciliation.js'
+
+const reconciliation = () => reconcileLeadTime(vsmDataStore.steps, vsmDataStore.dora)
+
+When('I view the DORA panel', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+When('I record an actual lead time for changes of {int} minutes', function (minutes) {
+  vsmDataStore.setDora({ leadTimeForChangesMinutes: minutes })
+})
+
+When('I record the following DORA metrics:', function (dataTable) {
+  const updates = {}
+  dataTable.raw().forEach(([key, value]) => {
+    updates[key] = Number(value)
+  })
+  vsmDataStore.setDora(updates)
+})
+
+Then('the lead-time reconciliation status is {string}', function (status) {
+  expect(reconciliation().status).to.equal(status)
+})
+
+Then('the lead-time reconciliation shows a hidden queue of {int} minutes', function (minutes) {
+  expect(reconciliation().hiddenQueue).to.equal(minutes)
+})
+
+Then('the {string} DORA metric is rated {string}', function (metric, tier) {
+  expect(classifyDora(vsmDataStore.dora)[metric]).to.equal(tier)
+})

--- a/features/step-definitions/futureState.steps.js
+++ b/features/step-definitions/futureState.steps.js
@@ -1,0 +1,38 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { compareStates } from '../../src/utils/calculations/futureState.js'
+
+const stepByName = (name) => vsmDataStore.steps.find((s) => s.name === name)
+
+const comparison = () =>
+  compareStates(
+    vsmDataStore.baseline?.steps ?? null,
+    vsmDataStore.baseline?.connections ?? [],
+    vsmDataStore.steps,
+    vsmDataStore.connections
+  )
+
+When('I view the state comparison', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+When('I capture the current state as the baseline', function () {
+  vsmDataStore.captureBaseline()
+})
+
+When('I reduce the lead time of {string} to {int}', function (name, leadTime) {
+  vsmDataStore.updateStep(stepByName(name).id, { leadTime })
+})
+
+Then('there is no state comparison', function () {
+  expect(comparison()).to.equal(null)
+})
+
+Then('the future-state total lead time delta is {int} minutes', function (delta) {
+  expect(comparison().deltas.totalLeadTime.delta).to.equal(delta)
+})
+
+Then('the future-state total lead time is improved', function () {
+  expect(comparison().deltas.totalLeadTime.improved).to.equal(true)
+})

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -8,6 +8,7 @@ import { createStep } from '../../../src/models/StepFactory.js'
 import { createConnection } from '../../../src/models/ConnectionFactory.js'
 import { calculateMetrics } from '../../../src/utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../../../src/utils/calculations/cdReadiness.js'
+import { createAnnotation } from '../../../src/utils/annotations.js'
 import { EXAMPLE_MAP } from '../../../src/data/exampleMaps.js'
 // MAP_TEMPLATES is available if needed for template loading tests
 
@@ -23,6 +24,7 @@ function createTestVsmDataStore() {
   let createdAt = null
   let updatedAt = null
   let readinessOverrides = {}
+  let annotations = []
 
   return {
     get id() {
@@ -55,6 +57,17 @@ function createTestVsmDataStore() {
     get readinessOverrides() {
       return readinessOverrides
     },
+    get annotations() {
+      return annotations
+    },
+    addAnnotation(targetType, targetId, wasteType, note = '') {
+      const annotation = createAnnotation(targetType, targetId, wasteType, note)
+      annotations = [...annotations, annotation]
+      return annotation
+    },
+    removeAnnotation(annotationId) {
+      annotations = annotations.filter((a) => a.id !== annotationId)
+    },
 
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -66,6 +79,7 @@ function createTestVsmDataStore() {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      annotations = []
     },
 
     setReadinessOverride(itemId, status) {
@@ -101,6 +115,7 @@ function createTestVsmDataStore() {
       createdAt = mapData.createdAt
       updatedAt = mapData.updatedAt
       readinessOverrides = mapData.readinessOverrides || {}
+      annotations = mapData.annotations || []
     },
 
     clearMap() {
@@ -112,6 +127,7 @@ function createTestVsmDataStore() {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      annotations = []
     },
 
     addStep(stepName = 'New Step', overrides = {}) {
@@ -133,9 +149,17 @@ function createTestVsmDataStore() {
     },
 
     deleteStep(stepId) {
+      const removedConnectionIds = connections
+        .filter((conn) => conn.source === stepId || conn.target === stepId)
+        .map((conn) => conn.id)
       steps = steps.filter((step) => step.id !== stepId)
       connections = connections.filter(
         (conn) => conn.source !== stepId && conn.target !== stepId
+      )
+      annotations = annotations.filter(
+        (a) =>
+          !(a.targetType === 'step' && a.targetId === stepId) &&
+          !(a.targetType === 'connection' && removedConnectionIds.includes(a.targetId))
       )
       updatedAt = new Date().toISOString()
     },
@@ -310,6 +334,7 @@ function createTestVsmIOStore(dataStore) {
         createdAt: dataStore.createdAt,
         updatedAt: dataStore.updatedAt,
         readinessOverrides: dataStore.readinessOverrides,
+        annotations: dataStore.annotations,
       })
     },
 

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -23,6 +23,7 @@ function createTestVsmDataStore() {
   let createdAt = null
   let updatedAt = null
   let readinessOverrides = {}
+  let baseline = null
 
   return {
     get id() {
@@ -55,6 +56,19 @@ function createTestVsmDataStore() {
     get readinessOverrides() {
       return readinessOverrides
     },
+    get baseline() {
+      return baseline
+    },
+    captureBaseline() {
+      baseline = {
+        steps: steps.map((s) => ({ ...s })),
+        connections: connections.map((c) => ({ ...c })),
+        capturedAt: new Date().toISOString(),
+      }
+    },
+    clearBaseline() {
+      baseline = null
+    },
 
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -66,6 +80,7 @@ function createTestVsmDataStore() {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      baseline = null
     },
 
     setReadinessOverride(itemId, status) {
@@ -101,6 +116,7 @@ function createTestVsmDataStore() {
       createdAt = mapData.createdAt
       updatedAt = mapData.updatedAt
       readinessOverrides = mapData.readinessOverrides || {}
+      baseline = mapData.baseline || null
     },
 
     clearMap() {
@@ -112,6 +128,7 @@ function createTestVsmDataStore() {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      baseline = null
     },
 
     addStep(stepName = 'New Step', overrides = {}) {
@@ -310,6 +327,7 @@ function createTestVsmIOStore(dataStore) {
         createdAt: dataStore.createdAt,
         updatedAt: dataStore.updatedAt,
         readinessOverrides: dataStore.readinessOverrides,
+        baseline: dataStore.baseline,
       })
     },
 

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -8,6 +8,7 @@ import { createStep } from '../../../src/models/StepFactory.js'
 import { createConnection } from '../../../src/models/ConnectionFactory.js'
 import { calculateMetrics } from '../../../src/utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../../../src/utils/calculations/cdReadiness.js'
+import { emptyDora } from '../../../src/utils/calculations/doraReconciliation.js'
 import { EXAMPLE_MAP } from '../../../src/data/exampleMaps.js'
 // MAP_TEMPLATES is available if needed for template loading tests
 
@@ -23,6 +24,7 @@ function createTestVsmDataStore() {
   let createdAt = null
   let updatedAt = null
   let readinessOverrides = {}
+  let dora = emptyDora()
 
   return {
     get id() {
@@ -55,6 +57,12 @@ function createTestVsmDataStore() {
     get readinessOverrides() {
       return readinessOverrides
     },
+    get dora() {
+      return dora
+    },
+    setDora(updates) {
+      dora = { ...dora, ...updates }
+    },
 
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -66,6 +74,7 @@ function createTestVsmDataStore() {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      dora = emptyDora()
     },
 
     setReadinessOverride(itemId, status) {
@@ -101,6 +110,7 @@ function createTestVsmDataStore() {
       createdAt = mapData.createdAt
       updatedAt = mapData.updatedAt
       readinessOverrides = mapData.readinessOverrides || {}
+      dora = mapData.dora || emptyDora()
     },
 
     clearMap() {
@@ -112,6 +122,7 @@ function createTestVsmDataStore() {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      dora = emptyDora()
     },
 
     addStep(stepName = 'New Step', overrides = {}) {
@@ -310,6 +321,7 @@ function createTestVsmIOStore(dataStore) {
         createdAt: dataStore.createdAt,
         updatedAt: dataStore.updatedAt,
         readinessOverrides: dataStore.readinessOverrides,
+        dora: dataStore.dora,
       })
     },
 

--- a/features/step-definitions/kaizen.steps.js
+++ b/features/step-definitions/kaizen.steps.js
@@ -1,0 +1,34 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import {
+  groupAnnotationsByWaste,
+  summarizeAnnotations,
+} from '../../src/utils/annotations.js'
+
+const stepByName = (name) => vsmDataStore.steps.find((s) => s.name === name)
+
+When(
+  'I annotate the {string} step with {string} waste noted {string}',
+  function (stepName, wasteType, note) {
+    const step = stepByName(stepName)
+    this.lastAnnotation = vsmDataStore.addAnnotation('step', step.id, wasteType, note)
+  }
+)
+
+When('I remove that annotation', function () {
+  vsmDataStore.removeAnnotation(this.lastAnnotation.id)
+})
+
+When('I delete the {string} step', function (stepName) {
+  vsmDataStore.deleteStep(stepByName(stepName).id)
+})
+
+Then('the improvement backlog has {int} kaizen burst(s)', function (count) {
+  expect(summarizeAnnotations(vsmDataStore.annotations).total).to.equal(count)
+})
+
+Then('the backlog has {int} {string} annotation(s)', function (count, wasteType) {
+  const group = groupAnnotationsByWaste(vsmDataStore.annotations)[wasteType] || []
+  expect(group).to.have.lengthOf(count)
+})

--- a/features/step-definitions/monteCarlo.steps.js
+++ b/features/step-definitions/monteCarlo.steps.js
@@ -1,0 +1,23 @@
+import { When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { runMonteCarlo } from '../../src/utils/simulation/monteCarlo.js'
+
+When('I run a Monte-Carlo simulation with {int}% variability', function (percent) {
+  this.mcOptions = { trials: 500, variability: percent / 100, seed: 7 }
+  this.mc = runMonteCarlo(vsmDataStore.steps, this.mcOptions)
+})
+
+Then('the P50 lead time is {int} minutes', function (minutes) {
+  expect(this.mc.p50).to.equal(minutes)
+})
+
+Then('the P95 lead time is at least the P50 lead time', function () {
+  expect(this.mc.p95).to.be.at.least(this.mc.p50)
+})
+
+Then('the simulation is reproducible for the same seed', function () {
+  const repeat = runMonteCarlo(vsmDataStore.steps, this.mcOptions)
+  expect(repeat.p95).to.equal(this.mc.p95)
+  expect(repeat.mean).to.equal(this.mc.mean)
+})

--- a/features/step-definitions/recommendations.steps.js
+++ b/features/step-definitions/recommendations.steps.js
@@ -1,0 +1,44 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { generateRecommendations } from '../../src/utils/calculations/recommendations.js'
+
+const recs = () =>
+  generateRecommendations(vsmDataStore.cdReadiness, vsmDataStore.metrics.bottleneckIds)
+
+const recById = (id) => recs().find((r) => r.id === id)
+
+Given('a healthy value stream with an automated deployment', function () {
+  this.vsm.createVSM('Healthy Map')
+  this.vsm.addStep('Development', {
+    type: 'development',
+    processTime: 120,
+    leadTime: 360,
+    percentCompleteAccurate: 100,
+  })
+  this.vsm.addStep('Deploy', { type: 'deployment', processTime: 60, leadTime: 180, automated: true })
+})
+
+When('I view the recommendations', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+Then('there are no recommendations', function () {
+  expect(recs()).to.have.lengthOf(0)
+})
+
+Then('there is a recommendation for {string}', function (id) {
+  expect(recById(id)).to.exist
+})
+
+Then('the recommendation for {string} deep-links to the practice guide', function (id) {
+  expect(recById(id).link).to.match(/beyond\.minimumcd\.org/)
+})
+
+Then('the first recommendation is for {string}', function (id) {
+  expect(recs()[0].id).to.equal(id)
+})
+
+Then('the recommendation for {string} is marked as a constraint', function (id) {
+  expect(recById(id).priority).to.equal('high')
+})

--- a/features/step-definitions/waitTime.steps.js
+++ b/features/step-definitions/waitTime.steps.js
@@ -1,0 +1,43 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import { calculateWaitTimeBreakdown } from '../../src/utils/calculations/waitTime.js'
+
+const rowByName = (name) =>
+  calculateWaitTimeBreakdown(vsmDataStore.steps).steps.find((r) => r.name === name)
+
+Given(
+  'a manual approval step {string} with process time {int} and lead time {int}',
+  function (name, pt, lt) {
+    this.vsm.createVSM('Waterfall Map')
+    this.vsm.addStep(name, { processTime: pt, leadTime: lt, automated: false })
+  }
+)
+
+When('I view the wait-time waterfall', function () {
+  // Derived from store state; nothing to trigger.
+})
+
+Then('I see a message to add steps for the waterfall', function () {
+  expect(vsmDataStore.steps).to.have.lengthOf(0)
+})
+
+Then('the wait-time waterfall shows {string} as {int}% waiting', function (name, percentage) {
+  expect(rowByName(name).waitPercentage).to.equal(percentage)
+})
+
+Then('{string} is flagged as a hidden queue', function (name) {
+  expect(rowByName(name).waitDominated).to.equal(true)
+})
+
+Then('{string} is not flagged as a hidden queue', function (name) {
+  expect(rowByName(name).waitDominated).to.equal(false)
+})
+
+Then('{string} is flagged as a handoff', function (name) {
+  expect(rowByName(name).manual).to.equal(true)
+})
+
+Then('the wait-time summary shows {int}% waiting', function (percentage) {
+  expect(calculateWaitTimeBreakdown(vsmDataStore.steps).totals.waitPercentage).to.equal(percentage)
+})

--- a/features/step-definitions/wipLevers.steps.js
+++ b/features/step-definitions/wipLevers.steps.js
@@ -1,0 +1,48 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore } from './helpers/testStores.js'
+import {
+  wipFromLittlesLaw,
+  projectBatchSizeChange,
+} from '../../src/utils/calculations/littlesLaw.js'
+import { calculateTotalLeadTime } from '../../src/utils/calculations/metrics.js'
+
+const stepByName = (name) => vsmDataStore.steps.find((s) => s.name === name)
+
+Given(
+  'a step {string} with process time {int}, lead time {int}, and batch size {int}',
+  function (name, pt, lt, batch) {
+    this.vsm.createVSM('Levers Map')
+    this.vsm.addStep(name, { processTime: pt, leadTime: lt, batchSize: batch })
+  }
+)
+
+When('the team throughput is {int} items per day', function (throughput) {
+  this.throughput = throughput
+})
+
+When('I project halving the batch size of {string}', function (name) {
+  const step = stepByName(name)
+  this.projection = projectBatchSizeChange(step, Math.ceil(step.batchSize / 2))
+})
+
+When('I project doubling the batch size of {string}', function (name) {
+  const step = stepByName(name)
+  this.projection = projectBatchSizeChange(step, step.batchSize * 2)
+})
+
+Then('the estimated work in progress is {int} items', function (items) {
+  const totalLead = calculateTotalLeadTime(vsmDataStore.steps)
+  expect(wipFromLittlesLaw(this.throughput, totalLead)).to.equal(items)
+})
+
+Then('the projected lead time for {string} is {int} minutes', function (_name, minutes) {
+  expect(this.projection.projectedLeadTime).to.equal(minutes)
+})
+
+Then(
+  'the projected lead time for {string} is greater than {int} minutes',
+  function (_name, minutes) {
+    expect(this.projection.projectedLeadTime).to.be.greaterThan(minutes)
+  }
+)

--- a/features/visualization/dora-reconciliation.feature
+++ b/features/visualization/dora-reconciliation.feature
@@ -1,0 +1,44 @@
+Feature: DORA Reconciliation
+  As a team facilitator running a Phase 0 assessment
+  I want to record our DORA metrics and compare actual lead time to the map
+  So that I can find the hidden queue the value stream does not yet show
+
+  Scenario: Reconciliation is unknown until an actual lead time is recorded
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 480      |
+    When I view the DORA panel
+    Then the lead-time reconciliation status is "unknown"
+
+  Scenario: A much larger actual lead time reveals a hidden queue
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 480      |
+    When I record an actual lead time for changes of 4800 minutes
+    Then the lead-time reconciliation status is "hidden-queue"
+    And the lead-time reconciliation shows a hidden queue of 4320 minutes
+
+  Scenario: A close actual lead time is aligned
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 1000     |
+    When I record an actual lead time for changes of 1100 minutes
+    Then the lead-time reconciliation status is "aligned"
+
+  Scenario: Classifies elite performance
+    Given an empty value stream map
+    When I record the following DORA metrics:
+      | deploymentFrequencyPerDay | 5   |
+      | leadTimeForChangesMinutes | 600 |
+      | changeFailureRatePct      | 10  |
+      | mttrMinutes               | 30  |
+    Then the "leadTimeForChanges" DORA metric is rated "elite"
+    And the "changeFailureRate" DORA metric is rated "elite"
+
+  Scenario: DORA metrics survive save and reload
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 480      |
+    And I record an actual lead time for changes of 4800 minutes
+    When the map is saved and reloaded
+    Then the lead-time reconciliation shows a hidden queue of 4320 minutes

--- a/features/visualization/recommendations.feature
+++ b/features/visualization/recommendations.feature
@@ -1,0 +1,27 @@
+Feature: Constraint Recommendations
+  As a team facilitator
+  I want prescriptive countermeasures for the problems in my value stream
+  So that I know what to improve first
+
+  Scenario: A healthy stream yields no recommendations
+    Given a healthy value stream with an automated deployment
+    When I view the recommendations
+    Then there are no recommendations
+
+  Scenario: A long lead time produces a work-decomposition countermeasure
+    Given a value stream with steps:
+      | name        | processTime | leadTime |
+      | Development  | 120         | 1200     |
+    When I view the recommendations
+    Then there is a recommendation for "work-decomposition"
+    And the recommendation for "work-decomposition" deep-links to the practice guide
+
+  Scenario: The constraint is recommended first
+    Given a value stream with steps:
+      | name   | processTime | leadTime | queueSize |
+      | Intake | 30          | 1200     | 2         |
+      | Build  | 60          | 240      | 2         |
+      | Review | 30          | 480      | 25        |
+    When I view the recommendations
+    Then the first recommendation is for "wip-limits"
+    And the recommendation for "wip-limits" is marked as a constraint

--- a/features/visualization/wait-time-waterfall.feature
+++ b/features/visualization/wait-time-waterfall.feature
@@ -1,0 +1,43 @@
+Feature: Wait-Time Waterfall
+  As a team facilitator
+  I want to see how much of each step's lead time is spent waiting
+  So that I can find the hidden queues and handoffs that slow delivery
+
+  Scenario: Empty stream prompts to add steps
+    Given an empty value stream map
+    When I view the wait-time waterfall
+    Then I see a message to add steps for the waterfall
+
+  Scenario: Splits a step into value-add and wait time
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 60          | 240      |
+    When I view the wait-time waterfall
+    Then the wait-time waterfall shows "Dev" as 75% waiting
+
+  Scenario: Flags a wait-dominated step as a hidden queue
+    Given a value stream with steps:
+      | name   | processTime | leadTime |
+      | Review | 10          | 200      |
+    When I view the wait-time waterfall
+    Then "Review" is flagged as a hidden queue
+
+  Scenario: Does not flag a value-add-dominated step
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 180         | 200      |
+    When I view the wait-time waterfall
+    Then "Dev" is not flagged as a hidden queue
+
+  Scenario: Flags a manual step as a handoff
+    Given a manual approval step "Sign-off" with process time 5 and lead time 480
+    When I view the wait-time waterfall
+    Then "Sign-off" is flagged as a handoff
+
+  Scenario: Summarises the overall wait percentage
+    Given a value stream with steps:
+      | name | processTime | leadTime |
+      | Dev  | 60          | 240      |
+      | Test | 40          | 160      |
+    When I view the wait-time waterfall
+    Then the wait-time summary shows 75% waiting

--- a/features/visualization/wip-batch-levers.feature
+++ b/features/visualization/wip-batch-levers.feature
@@ -1,0 +1,21 @@
+Feature: WIP and Batch-Size Levers
+  As a team facilitator
+  I want to apply Little's Law and project batch-size changes
+  So that I can reason about WIP and small batches as flow levers
+
+  Scenario: Estimate WIP from Little's Law
+    Given a value stream with steps:
+      | name | leadTime |
+      | Dev  | 960      |
+    When the team throughput is 2 items per day
+    Then the estimated work in progress is 4 items
+
+  Scenario: Halving a step's batch size shortens its lead time
+    Given a step "Build" with process time 60, lead time 240, and batch size 4
+    When I project halving the batch size of "Build"
+    Then the projected lead time for "Build" is 150 minutes
+
+  Scenario: Growing a step's batch size lengthens its lead time
+    Given a step "Build" with process time 60, lead time 240, and batch size 4
+    When I project doubling the batch size of "Build"
+    Then the projected lead time for "Build" is greater than 240 minutes

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import MonteCarloPanel from './components/metrics/MonteCarloPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <MonteCarloPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import FutureStatePanel from './components/metrics/FutureStatePanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <FutureStatePanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import WipLeversPanel from './components/metrics/WipLeversPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <WipLeversPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import WaitTimeWaterfall from './components/metrics/WaitTimeWaterfall.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -94,6 +95,7 @@
           </div>
           <SimulationPanel />
           <MetricsDashboard />
+          <WaitTimeWaterfall />
           <CdReadinessScorecard />
         </main>
         <EditorPanel

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import DoraPanel from './components/metrics/DoraPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <DoraPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import AnnotationsPanel from './components/metrics/AnnotationsPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <AnnotationsPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
+  import RecommendationsPanel from './components/metrics/RecommendationsPanel.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -95,6 +96,7 @@
           <SimulationPanel />
           <MetricsDashboard />
           <CdReadinessScorecard />
+          <RecommendationsPanel />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/metrics/AnnotationsPanel.svelte
+++ b/src/components/metrics/AnnotationsPanel.svelte
@@ -1,0 +1,133 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { WASTE_TYPES, WASTE_TYPE_LABELS } from '../../data/wasteTypes.js'
+  import {
+    groupAnnotationsByWaste,
+    summarizeAnnotations,
+  } from '../../utils/annotations.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let connections = $derived(vsmDataStore.connections)
+  let annotations = $derived(vsmDataStore.annotations)
+  let grouped = $derived(groupAnnotationsByWaste(annotations))
+  let summary = $derived(summarizeAnnotations(annotations))
+
+  let targetId = $state('')
+  let wasteType = $state(WASTE_TYPES.WAITING)
+  let note = $state('')
+
+  // Targets the user can annotate: steps and connections (labelled by step names).
+  let targets = $derived([
+    ...steps.map((s) => ({ id: s.id, type: 'step', label: `Step: ${s.name}` })),
+    ...connections.map((c) => ({
+      id: c.id,
+      type: 'connection',
+      label: `Edge: ${stepName(c.source)} → ${stepName(c.target)}`,
+    })),
+  ])
+
+  function stepName(id) {
+    return steps.find((s) => s.id === id)?.name ?? '?'
+  }
+
+  function targetLabel(annotation) {
+    return targets.find((t) => t.id === annotation.targetId)?.label ?? '(removed)'
+  }
+
+  function handleAdd() {
+    const target = targets.find((t) => t.id === targetId)
+    if (!target) return
+    vsmDataStore.addAnnotation(target.type, target.id, wasteType, note.trim())
+    note = ''
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="annotations-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Improvement Backlog
+    <span class="ml-2 text-xs font-normal text-gray-500" data-testid="annotations-summary">
+      {summary.total} kaizen {summary.total === 1 ? 'burst' : 'bursts'}
+    </span>
+  </summary>
+
+  {#if targets.length === 0}
+    <p class="mt-3 text-sm text-gray-500">Add steps to annotate improvement opportunities.</p>
+  {:else}
+    <div class="mt-3 flex flex-wrap items-end gap-2">
+      <label class="text-xs font-medium text-gray-700">
+        Target
+        <select
+          bind:value={targetId}
+          class="mt-1 block rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="annotation-target-select"
+        >
+          <option value="" disabled>Choose…</option>
+          {#each targets as t (t.id)}
+            <option value={t.id}>{t.label}</option>
+          {/each}
+        </select>
+      </label>
+      <label class="text-xs font-medium text-gray-700">
+        Waste
+        <select
+          bind:value={wasteType}
+          class="mt-1 block rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="annotation-waste-select"
+        >
+          {#each Object.entries(WASTE_TYPE_LABELS) as [value, label] (value)}
+            <option {value}>{label}</option>
+          {/each}
+        </select>
+      </label>
+      <input
+        bind:value={note}
+        placeholder="Note (optional)"
+        class="flex-1 rounded-md border border-gray-300 px-2 py-1 text-sm"
+        data-testid="annotation-note-input"
+      />
+      <button
+        type="button"
+        onclick={handleAdd}
+        disabled={!targetId}
+        class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        data-testid="annotation-add-button"
+      >
+        Add burst
+      </button>
+    </div>
+
+    {#if annotations.length > 0}
+      <div class="mt-4 space-y-3">
+        {#each Object.entries(grouped) as [waste, items] (waste)}
+          <section data-testid="waste-group-{waste}">
+            <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500">
+              {WASTE_TYPE_LABELS[waste]} ({items.length})
+            </h4>
+            <ul class="mt-1 space-y-1">
+              {#each items as a (a.id)}
+                <li
+                  class="flex items-center justify-between rounded border border-amber-200 bg-amber-50 px-2 py-1 text-xs"
+                  data-testid="annotation-{a.id}"
+                >
+                  <span>
+                    <span class="font-medium">{targetLabel(a)}</span>
+                    {#if a.note}<span class="text-gray-600"> — {a.note}</span>{/if}
+                  </span>
+                  <button
+                    type="button"
+                    onclick={() => vsmDataStore.removeAnnotation(a.id)}
+                    class="text-red-600 hover:text-red-800"
+                    aria-label="Remove annotation"
+                    data-testid="annotation-remove-{a.id}"
+                  >
+                    ✕
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</details>

--- a/src/components/metrics/DoraPanel.svelte
+++ b/src/components/metrics/DoraPanel.svelte
@@ -1,0 +1,87 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import {
+    reconcileLeadTime,
+    classifyDora,
+  } from '../../utils/calculations/doraReconciliation.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let dora = $derived(vsmDataStore.dora)
+  let reconciliation = $derived(reconcileLeadTime(steps, dora))
+  let tiers = $derived(classifyDora(dora))
+
+  const tierColors = {
+    elite: 'bg-green-100 text-green-800',
+    high: 'bg-blue-100 text-blue-800',
+    medium: 'bg-amber-100 text-amber-800',
+    low: 'bg-red-100 text-red-800',
+    unknown: 'bg-gray-100 text-gray-600',
+  }
+
+  const reconColors = {
+    'hidden-queue': 'text-red-700',
+    'optimistic-map': 'text-amber-700',
+    aligned: 'text-green-700',
+    unknown: 'text-gray-600',
+  }
+
+  // Number input that writes null when blank.
+  function onInput(field, raw) {
+    const value = raw === '' ? null : Number(raw)
+    vsmDataStore.setDora({ [field]: value })
+  }
+
+  const fields = [
+    { key: 'deploymentFrequencyPerDay', label: 'Deploy freq (per day)', tier: 'deploymentFrequency' },
+    { key: 'leadTimeForChangesMinutes', label: 'Lead time for changes (min)', tier: 'leadTimeForChanges' },
+    { key: 'changeFailureRatePct', label: 'Change failure rate (%)', tier: 'changeFailureRate' },
+    { key: 'mttrMinutes', label: 'MTTR (min)', tier: 'mttr' },
+  ]
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="dora-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">DORA Reconciliation</summary>
+
+  <div class="mt-3 grid grid-cols-2 gap-3 md:grid-cols-4">
+    {#each fields as f (f.key)}
+      <label class="block text-xs font-medium text-gray-700">
+        {f.label}
+        <input
+          type="number"
+          min="0"
+          value={dora[f.key] ?? ''}
+          oninput={(e) => onInput(f.key, e.target.value)}
+          class="mt-1 w-full rounded-md border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          data-testid="dora-input-{f.key}"
+        />
+        <span
+          class="mt-1 inline-block rounded px-1 text-[10px] font-semibold uppercase {tierColors[tiers[f.tier]]}"
+          data-testid="dora-tier-{f.tier}"
+        >
+          {tiers[f.tier]}
+        </span>
+      </label>
+    {/each}
+  </div>
+
+  <div class="mt-3 rounded-md bg-gray-50 p-3 text-xs" data-testid="dora-reconciliation" data-status={reconciliation.status}>
+    {#if reconciliation.status === 'unknown'}
+      <p class="text-gray-600">Enter the actual lead time for changes to reconcile it against the map.</p>
+    {:else}
+      <p>
+        VSM-derived lead time: <strong>{formatDuration(reconciliation.vsmLeadTime)}</strong>
+        · Actual: <strong>{formatDuration(reconciliation.actualLeadTime)}</strong>
+      </p>
+      <p class="mt-1 {reconColors[reconciliation.status]}">
+        {#if reconciliation.status === 'hidden-queue'}
+          Hidden queue of <strong>{formatDuration(reconciliation.hiddenQueue)}</strong> the map does not yet show.
+        {:else if reconciliation.status === 'optimistic-map'}
+          The map shows more lead time than reality — check the step estimates.
+        {:else}
+          Map and actual lead time are aligned.
+        {/if}
+      </p>
+    {/if}
+  </div>
+</details>

--- a/src/components/metrics/FutureStatePanel.svelte
+++ b/src/components/metrics/FutureStatePanel.svelte
@@ -1,0 +1,79 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { compareStates } from '../../utils/calculations/futureState.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let connections = $derived(vsmDataStore.connections)
+  let baseline = $derived(vsmDataStore.baseline)
+
+  let comparison = $derived(
+    compareStates(baseline?.steps ?? null, baseline?.connections ?? [], steps, connections)
+  )
+
+  const rows = [
+    { key: 'totalLeadTime', label: 'Total lead time', fmt: formatDuration },
+    { key: 'totalProcessTime', label: 'Total process time', fmt: formatDuration },
+    { key: 'flowEfficiency', label: 'Flow efficiency', fmt: (v) => `${v.toFixed(1)}%` },
+    { key: 'firstPassYield', label: 'First pass yield', fmt: (v) => `${v.toFixed(1)}%` },
+  ]
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="future-state-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Current vs Future State
+  </summary>
+
+  <div class="mt-3 flex gap-2">
+    <button
+      type="button"
+      onclick={() => vsmDataStore.captureBaseline()}
+      class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700"
+      data-testid="capture-baseline-button"
+      disabled={steps.length === 0}
+    >
+      {baseline ? 'Re-capture baseline' : 'Capture current as baseline'}
+    </button>
+    {#if baseline}
+      <button
+        type="button"
+        onclick={() => vsmDataStore.clearBaseline()}
+        class="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+        data-testid="clear-baseline-button"
+      >
+        Clear
+      </button>
+    {/if}
+  </div>
+
+  {#if !comparison}
+    <p class="mt-3 text-sm text-gray-500">
+      Capture the current state as a baseline, then improve the map to see the projected deltas.
+    </p>
+  {:else}
+    <table class="mt-3 w-full text-xs" data-testid="state-comparison">
+      <thead class="text-left text-gray-500">
+        <tr>
+          <th class="py-1">Metric</th>
+          <th class="py-1">Baseline</th>
+          <th class="py-1">Working</th>
+          <th class="py-1">Delta</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row (row.key)}
+          {@const d = comparison.deltas[row.key]}
+          <tr class="border-t border-gray-100" data-testid="comparison-row-{row.key}" data-improved={d.improved}>
+            <td class="py-1 font-medium">{row.label}</td>
+            <td class="py-1">{row.fmt(d.baseline)}</td>
+            <td class="py-1">{row.fmt(d.working)}</td>
+            <td class="py-1 {d.improved ? 'text-green-700' : d.delta === 0 ? 'text-gray-500' : 'text-red-700'}">
+              {d.delta > 0 ? '+' : ''}{row.fmt(d.delta)}
+              {#if d.improved}<span class="ml-1">↓ improved</span>{/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</details>

--- a/src/components/metrics/MonteCarloPanel.svelte
+++ b/src/components/metrics/MonteCarloPanel.svelte
@@ -1,0 +1,85 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { runMonteCarlo } from '../../utils/simulation/monteCarlo.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+
+  let variability = $state(0.25)
+  let trials = $state(1000)
+  let result = $state(null)
+
+  function run() {
+    result = runMonteCarlo(steps, { trials, variability, seed: 1 })
+  }
+
+  // Re-run is explicit (button), so results don't churn while editing the map.
+  const percentiles = $derived(
+    result
+      ? [
+          { label: 'P50 (typical)', value: result.p50 },
+          { label: 'P85 (likely worst)', value: result.p85 },
+          { label: 'P95 (rare worst)', value: result.p95 },
+          { label: 'Mean', value: result.mean },
+        ]
+      : []
+  )
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="monte-carlo-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Monte-Carlo Lead Time
+  </summary>
+
+  {#if steps.length === 0}
+    <p class="mt-3 text-sm text-gray-500">Add steps to simulate lead-time variability.</p>
+  {:else}
+    <div class="mt-3 flex flex-wrap items-end gap-3">
+      <label class="text-xs font-medium text-gray-700">
+        Variability: {Math.round(variability * 100)}%
+        <input
+          type="range"
+          min="0"
+          max="0.6"
+          step="0.05"
+          bind:value={variability}
+          class="mt-1 block w-40"
+          data-testid="variability-input"
+        />
+      </label>
+      <label class="text-xs font-medium text-gray-700">
+        Trials
+        <input
+          type="number"
+          min="10"
+          step="100"
+          bind:value={trials}
+          class="ml-1 w-24 rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="trials-input"
+        />
+      </label>
+      <button
+        type="button"
+        onclick={run}
+        class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700"
+        data-testid="run-monte-carlo-button"
+      >
+        Run
+      </button>
+    </div>
+
+    {#if result}
+      <div class="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4" data-testid="monte-carlo-results">
+        {#each percentiles as p (p.label)}
+          <div class="rounded-md border border-gray-200 p-2 text-center">
+            <div class="text-[10px] uppercase tracking-wide text-gray-500">{p.label}</div>
+            <div class="text-sm font-bold text-gray-800">{formatDuration(p.value)}</div>
+          </div>
+        {/each}
+      </div>
+      <p class="mt-2 text-[11px] text-gray-400">
+        {trials} trials. The spread between P50 and P95 is the risk variability adds to your lead time.
+      </p>
+    {/if}
+  {/if}
+</details>

--- a/src/components/metrics/RecommendationsPanel.svelte
+++ b/src/components/metrics/RecommendationsPanel.svelte
@@ -1,0 +1,68 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { generateRecommendations } from '../../utils/calculations/recommendations.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let readiness = $derived(vsmDataStore.cdReadiness)
+  let bottleneckIds = $derived(vsmDataStore.metrics.bottleneckIds)
+  let recommendations = $derived(generateRecommendations(readiness, bottleneckIds))
+
+  const priorityColors = {
+    high: 'bg-red-100 text-red-800',
+    medium: 'bg-amber-100 text-amber-800',
+    low: 'bg-gray-100 text-gray-700',
+  }
+
+  function stepName(id) {
+    return steps.find((s) => s.id === id)?.name
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="recommendations-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Recommendations
+    {#if recommendations.length > 0}
+      <span class="ml-2 text-xs font-normal text-gray-500" data-testid="recommendations-summary">
+        {recommendations.length} to act on
+      </span>
+    {/if}
+  </summary>
+
+  {#if recommendations.length === 0}
+    <p class="mt-3 text-sm text-gray-500">
+      No constraints detected — add steps or resolve readiness gaps to see recommendations.
+    </p>
+  {:else}
+    <ul class="mt-3 space-y-2">
+      {#each recommendations as rec (rec.id)}
+        <li
+          class="rounded-md border border-gray-200 p-3"
+          data-testid="recommendation-{rec.id}"
+          data-priority={rec.priority}
+        >
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-medium text-gray-800">{rec.title}</span>
+            <span
+              class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase {priorityColors[rec.priority]}"
+            >
+              {rec.priority === 'high' ? 'constraint' : rec.priority}
+            </span>
+          </div>
+          <p class="mt-1 text-xs text-gray-600">{rec.finding}</p>
+          <p class="mt-1 text-xs font-medium text-gray-800">→ {rec.countermeasure}</p>
+          {#if rec.targetStepId && stepName(rec.targetStepId)}
+            <p class="mt-1 text-xs text-gray-500">Step: {stepName(rec.targetStepId)}</p>
+          {/if}
+          <a
+            href={rec.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mt-1 inline-block text-xs underline text-blue-600 hover:text-blue-800"
+          >
+            Learn more
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</details>

--- a/src/components/metrics/WaitTimeWaterfall.svelte
+++ b/src/components/metrics/WaitTimeWaterfall.svelte
@@ -1,0 +1,80 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { calculateWaitTimeBreakdown } from '../../utils/calculations/waitTime.js'
+  import { formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let breakdown = $derived(calculateWaitTimeBreakdown(steps))
+
+  function pct(value, total) {
+    return total > 0 ? (value / total) * 100 : 0
+  }
+</script>
+
+<details
+  class="bg-white border-t border-gray-200 px-6 py-4"
+  data-testid="wait-time-waterfall"
+  open
+>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Wait-Time Waterfall
+    {#if steps.length > 0}
+      <span class="ml-2 text-xs font-normal text-gray-500" data-testid="wait-time-summary">
+        {breakdown.totals.waitPercentage}% of lead time is waiting
+      </span>
+    {/if}
+  </summary>
+
+  {#if steps.length === 0}
+    <p class="mt-3 text-sm text-gray-500">
+      Add steps to your value stream to see where time is spent waiting.
+    </p>
+  {:else}
+    <ul class="mt-3 space-y-2">
+      {#each breakdown.steps as row (row.stepId)}
+        <li data-testid="wait-row-{row.stepId}" data-wait-dominated={row.waitDominated}>
+          <div class="flex items-center justify-between text-xs text-gray-700">
+            <span class="font-medium">
+              {row.name}
+              {#if row.manual}
+                <span
+                  class="ml-1 rounded bg-red-100 px-1 text-[10px] font-semibold text-red-700"
+                  data-testid="handoff-badge-{row.stepId}"
+                >
+                  handoff
+                </span>
+              {/if}
+              {#if row.waitDominated}
+                <span
+                  class="ml-1 rounded bg-amber-100 px-1 text-[10px] font-semibold text-amber-700"
+                  data-testid="hidden-queue-badge-{row.stepId}"
+                >
+                  hidden queue
+                </span>
+              {/if}
+            </span>
+            <span class="text-gray-500">{row.waitPercentage}% waiting</span>
+          </div>
+          <div class="mt-1 flex h-4 w-full overflow-hidden rounded bg-gray-100" aria-hidden="true">
+            <div
+              class="bg-green-500"
+              style="width: {pct(row.processTime, row.leadTime)}%"
+              title="Value-add: {formatDuration(row.processTime)}"
+            ></div>
+            <div
+              class="bg-amber-400"
+              style="width: {pct(row.waitTime, row.leadTime)}%"
+              title="Waiting: {formatDuration(row.waitTime)}"
+            ></div>
+          </div>
+        </li>
+      {/each}
+    </ul>
+    <p class="mt-3 text-xs text-gray-500">
+      <span class="inline-block h-2 w-2 rounded-sm bg-green-500"></span> value-add
+      ({formatDuration(breakdown.totals.processTime)})
+      <span class="ml-3 inline-block h-2 w-2 rounded-sm bg-amber-400"></span> waiting
+      ({formatDuration(breakdown.totals.waitTime)})
+    </p>
+  {/if}
+</details>

--- a/src/components/metrics/WipLeversPanel.svelte
+++ b/src/components/metrics/WipLeversPanel.svelte
@@ -1,0 +1,73 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import {
+    wipFromLittlesLaw,
+    projectBatchSizeChange,
+  } from '../../utils/calculations/littlesLaw.js'
+  import { calculateTotalLeadTime, formatDuration } from '../../utils/calculations/metrics.js'
+
+  let steps = $derived(vsmDataStore.steps)
+  let throughputPerDay = $state(1)
+
+  let totalLeadTime = $derived(calculateTotalLeadTime(steps))
+  let totalWip = $derived(wipFromLittlesLaw(throughputPerDay, totalLeadTime))
+
+  // Project halving each step's batch size.
+  function halved(step) {
+    return projectBatchSizeChange(step, Math.max(1, Math.ceil((step.batchSize || 1) / 2)))
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="wip-levers-panel" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">WIP &amp; Batch Levers</summary>
+
+  {#if steps.length === 0}
+    <p class="mt-3 text-sm text-gray-500">Add steps to explore WIP and batch-size levers.</p>
+  {:else}
+    <div class="mt-3 flex items-center gap-3">
+      <label class="text-xs font-medium text-gray-700">
+        Throughput (items/day)
+        <input
+          type="number"
+          min="0"
+          step="0.1"
+          bind:value={throughputPerDay}
+          class="ml-1 w-20 rounded-md border border-gray-300 px-2 py-1 text-sm"
+          data-testid="throughput-input"
+        />
+      </label>
+      <span class="text-xs text-gray-600" data-testid="total-wip">
+        Little's Law WIP: <strong>{totalWip}</strong> items in progress
+      </span>
+    </div>
+
+    <table class="mt-3 w-full text-xs">
+      <thead class="text-left text-gray-500">
+        <tr>
+          <th class="py-1">Step</th>
+          <th class="py-1">Batch</th>
+          <th class="py-1">WIP</th>
+          <th class="py-1">Lead time</th>
+          <th class="py-1">Halve batch →</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each steps as step (step.id)}
+          <tr class="border-t border-gray-100" data-testid="lever-row-{step.id}">
+            <td class="py-1 font-medium">{step.name}</td>
+            <td class="py-1">{step.batchSize ?? 1}</td>
+            <td class="py-1">{wipFromLittlesLaw(throughputPerDay, step.leadTime)}</td>
+            <td class="py-1">{formatDuration(step.leadTime)}</td>
+            <td class="py-1 {halved(step).deltaMinutes < 0 ? 'text-green-700' : 'text-gray-600'}">
+              {formatDuration(halved(step).projectedLeadTime)}
+              ({halved(step).deltaPercent}%)
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <p class="mt-2 text-[11px] text-gray-400">
+      WIP = throughput × lead time (Little's Law). Batch projection assumes wait time scales with batch size.
+    </p>
+  {/if}
+</details>

--- a/src/data/thresholds.js
+++ b/src/data/thresholds.js
@@ -33,6 +33,8 @@ export const PROGRESS_MULTIPLIER = 10
 export const WORK_ITEM_MAX_LEAD_TIME_MINUTES = 960
 // A test step's suite should run in under 10 minutes.
 export const TEST_STEP_MAX_PROCESS_TIME_MINUTES = 10
+// A step whose wait time is at/above this % of lead time is a hidden queue.
+export const WAIT_DOMINATED_THRESHOLD = 50
 
 // Canvas layout constants have been moved to canvasConfig.js
 // Re-exported here for backward compatibility

--- a/src/data/wasteTypes.js
+++ b/src/data/wasteTypes.js
@@ -1,0 +1,29 @@
+/**
+ * Lean waste categories for Kaizen-burst annotations, adapted to software delivery.
+ * Used to tag improvement opportunities on steps and connections.
+ */
+export const WASTE_TYPES = {
+  WAITING: 'waiting',
+  HANDOFF: 'handoff',
+  REWORK: 'rework',
+  OVERPROCESSING: 'overprocessing',
+  OVERPRODUCTION: 'overproduction',
+  INVENTORY: 'inventory',
+  TASK_SWITCHING: 'task_switching',
+  PRACTICE_GAP: 'practice_gap',
+}
+
+/** Display labels for each waste type. */
+export const WASTE_TYPE_LABELS = {
+  [WASTE_TYPES.WAITING]: 'Waiting',
+  [WASTE_TYPES.HANDOFF]: 'Handoff',
+  [WASTE_TYPES.REWORK]: 'Rework / Defects',
+  [WASTE_TYPES.OVERPROCESSING]: 'Over-processing',
+  [WASTE_TYPES.OVERPRODUCTION]: 'Over-production',
+  [WASTE_TYPES.INVENTORY]: 'Inventory / WIP',
+  [WASTE_TYPES.TASK_SWITCHING]: 'Task switching',
+  [WASTE_TYPES.PRACTICE_GAP]: 'Practice gap',
+}
+
+/** True when the value is a recognized waste type. */
+export const isWasteType = (value) => Object.values(WASTE_TYPES).includes(value)

--- a/src/infrastructure/VsmJsonRepository.js
+++ b/src/infrastructure/VsmJsonRepository.js
@@ -17,9 +17,19 @@
  * @returns {string} JSON string representation
  */
 export function serializeVsm(vsm) {
-  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides } = vsm
+  const {
+    id,
+    name,
+    description,
+    steps,
+    connections,
+    createdAt,
+    updatedAt,
+    readinessOverrides,
+    baseline,
+  } = vsm
   return JSON.stringify(
-    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides },
+    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, baseline },
     null,
     2
   )
@@ -70,5 +80,6 @@ export function deserializeVsm(jsonString) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    baseline: data.baseline && typeof data.baseline === 'object' ? data.baseline : undefined,
   }
 }

--- a/src/infrastructure/VsmJsonRepository.js
+++ b/src/infrastructure/VsmJsonRepository.js
@@ -17,9 +17,19 @@
  * @returns {string} JSON string representation
  */
 export function serializeVsm(vsm) {
-  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides } = vsm
+  const {
+    id,
+    name,
+    description,
+    steps,
+    connections,
+    createdAt,
+    updatedAt,
+    readinessOverrides,
+    annotations,
+  } = vsm
   return JSON.stringify(
-    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides },
+    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, annotations },
     null,
     2
   )
@@ -70,5 +80,6 @@ export function deserializeVsm(jsonString) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    annotations: Array.isArray(data.annotations) ? data.annotations : undefined,
   }
 }

--- a/src/infrastructure/VsmJsonRepository.js
+++ b/src/infrastructure/VsmJsonRepository.js
@@ -17,9 +17,10 @@
  * @returns {string} JSON string representation
  */
 export function serializeVsm(vsm) {
-  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides } = vsm
+  const { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, dora } =
+    vsm
   return JSON.stringify(
-    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides },
+    { id, name, description, steps, connections, createdAt, updatedAt, readinessOverrides, dora },
     null,
     2
   )
@@ -70,5 +71,6 @@ export function deserializeVsm(jsonString) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    dora: data.dora && typeof data.dora === 'object' ? data.dora : undefined,
   }
 }

--- a/src/stores/vsmDataStore.svelte.js
+++ b/src/stores/vsmDataStore.svelte.js
@@ -9,6 +9,7 @@ import { createStep } from '../models/StepFactory.js'
 import { createConnection } from '../models/ConnectionFactory.js'
 import { calculateMetrics } from '../utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../utils/calculations/cdReadiness.js'
+import { emptyDora } from '../utils/calculations/doraReconciliation.js'
 import { sanitizeVSMData, validateVSMData } from '../utils/validation/vsmValidator.js'
 import { autoPositionStep } from '../utils/ui/autoPositionStep.js'
 import { vsmLocalStorageRepo } from '../infrastructure/VsmLocalStorageRepository.js'
@@ -34,6 +35,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
     createdAt: null,
     updatedAt: null,
     readinessOverrides: {},
+    dora: emptyDora(),
   }
 
   // Load persisted state; sanitize on read and validate to catch corrupted localStorage
@@ -51,6 +53,8 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
   let updatedAt = $state(persisted.updatedAt)
   // User confirm/override decisions for the CD readiness scorecard, keyed by item id
   let readinessOverrides = $state(persisted.readinessOverrides || {})
+  // DORA metrics for this map (P1c)
+  let dora = $state(persisted.dora || emptyDora())
 
   // Cached metrics — only recomputed when steps or connections change
   let cachedMetrics = $derived(calculateMetrics(steps, connections))
@@ -71,6 +75,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt,
       updatedAt,
       readinessOverrides,
+      dora,
     })
   }
 
@@ -113,6 +118,11 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       return readinessOverrides
     },
 
+    // DORA metrics for this map
+    get dora() {
+      return dora
+    },
+
     // Map-level Actions
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -124,6 +134,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      dora = emptyDora()
       persist()
     },
 
@@ -153,6 +164,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = safe.createdAt
       updatedAt = safe.updatedAt
       readinessOverrides = safe.readinessOverrides || {}
+      dora = safe.dora || emptyDora()
       persist()
     },
 
@@ -165,6 +177,14 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      dora = emptyDora()
+      persist()
+    },
+
+    // Update this map's DORA metrics (P1c)
+    setDora(updates) {
+      dora = { ...dora, ...updates }
+      updatedAt = new Date().toISOString()
       persist()
     },
 

--- a/src/stores/vsmDataStore.svelte.js
+++ b/src/stores/vsmDataStore.svelte.js
@@ -9,6 +9,7 @@ import { createStep } from '../models/StepFactory.js'
 import { createConnection } from '../models/ConnectionFactory.js'
 import { calculateMetrics } from '../utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../utils/calculations/cdReadiness.js'
+import { createAnnotation } from '../utils/annotations.js'
 import { sanitizeVSMData, validateVSMData } from '../utils/validation/vsmValidator.js'
 import { autoPositionStep } from '../utils/ui/autoPositionStep.js'
 import { vsmLocalStorageRepo } from '../infrastructure/VsmLocalStorageRepository.js'
@@ -34,6 +35,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
     createdAt: null,
     updatedAt: null,
     readinessOverrides: {},
+    annotations: [],
   }
 
   // Load persisted state; sanitize on read and validate to catch corrupted localStorage
@@ -51,6 +53,8 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
   let updatedAt = $state(persisted.updatedAt)
   // User confirm/override decisions for the CD readiness scorecard, keyed by item id
   let readinessOverrides = $state(persisted.readinessOverrides || {})
+  // Kaizen-burst improvement annotations for this map
+  let annotations = $state(persisted.annotations || [])
 
   // Cached metrics — only recomputed when steps or connections change
   let cachedMetrics = $derived(calculateMetrics(steps, connections))
@@ -71,6 +75,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt,
       updatedAt,
       readinessOverrides,
+      annotations,
     })
   }
 
@@ -113,6 +118,11 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       return readinessOverrides
     },
 
+    // Kaizen-burst improvement annotations
+    get annotations() {
+      return [...annotations]
+    },
+
     // Map-level Actions
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -124,6 +134,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      annotations = []
       persist()
     },
 
@@ -153,6 +164,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = safe.createdAt
       updatedAt = safe.updatedAt
       readinessOverrides = safe.readinessOverrides || {}
+      annotations = safe.annotations || []
       persist()
     },
 
@@ -165,6 +177,28 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      annotations = []
+      persist()
+    },
+
+    // Kaizen-burst annotation CRUD (per-map improvement backlog)
+    addAnnotation(targetType, targetId, wasteType, note = '') {
+      const annotation = createAnnotation(targetType, targetId, wasteType, note)
+      annotations = [...annotations, annotation]
+      updatedAt = new Date().toISOString()
+      persist()
+      return annotation
+    },
+
+    updateAnnotation(annotationId, updates) {
+      annotations = annotations.map((a) => (a.id === annotationId ? { ...a, ...updates } : a))
+      updatedAt = new Date().toISOString()
+      persist()
+    },
+
+    removeAnnotation(annotationId) {
+      annotations = annotations.filter((a) => a.id !== annotationId)
+      updatedAt = new Date().toISOString()
       persist()
     },
 
@@ -205,9 +239,18 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
     },
 
     deleteStep(stepId) {
+      const removedConnectionIds = connections
+        .filter((conn) => conn.source === stepId || conn.target === stepId)
+        .map((conn) => conn.id)
       steps = steps.filter((step) => step.id !== stepId)
       connections = connections.filter(
         (conn) => conn.source !== stepId && conn.target !== stepId
+      )
+      // Prune annotations targeting the removed step or its connections
+      annotations = annotations.filter(
+        (a) =>
+          !(a.targetType === 'step' && a.targetId === stepId) &&
+          !(a.targetType === 'connection' && removedConnectionIds.includes(a.targetId))
       )
       updatedAt = new Date().toISOString()
       persist()
@@ -245,6 +288,9 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
 
     deleteConnection(connectionId) {
       connections = connections.filter((conn) => conn.id !== connectionId)
+      annotations = annotations.filter(
+        (a) => !(a.targetType === 'connection' && a.targetId === connectionId)
+      )
       updatedAt = new Date().toISOString()
       persist()
     },

--- a/src/stores/vsmDataStore.svelte.js
+++ b/src/stores/vsmDataStore.svelte.js
@@ -51,6 +51,8 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
   let updatedAt = $state(persisted.updatedAt)
   // User confirm/override decisions for the CD readiness scorecard, keyed by item id
   let readinessOverrides = $state(persisted.readinessOverrides || {})
+  // Captured baseline (current-state) snapshot for future-state comparison
+  let baseline = $state(persisted.baseline || null)
 
   // Cached metrics — only recomputed when steps or connections change
   let cachedMetrics = $derived(calculateMetrics(steps, connections))
@@ -71,6 +73,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt,
       updatedAt,
       readinessOverrides,
+      baseline,
     })
   }
 
@@ -113,6 +116,11 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       return readinessOverrides
     },
 
+    // Captured baseline snapshot for current-vs-future-state comparison
+    get baseline() {
+      return baseline
+    },
+
     // Map-level Actions
     createNewMap(mapName) {
       const now = new Date().toISOString()
@@ -124,6 +132,22 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = now
       updatedAt = now
       readinessOverrides = {}
+      baseline = null
+      persist()
+    },
+
+    // Capture the live map as the baseline (current state) for comparison
+    captureBaseline() {
+      baseline = {
+        steps: steps.map((s) => ({ ...s })),
+        connections: connections.map((c) => ({ ...c })),
+        capturedAt: new Date().toISOString(),
+      }
+      persist()
+    },
+
+    clearBaseline() {
+      baseline = null
       persist()
     },
 
@@ -153,6 +177,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = safe.createdAt
       updatedAt = safe.updatedAt
       readinessOverrides = safe.readinessOverrides || {}
+      baseline = safe.baseline || null
       persist()
     },
 
@@ -165,6 +190,7 @@ function createVsmDataStore(repository = vsmLocalStorageRepo) {
       createdAt = null
       updatedAt = null
       readinessOverrides = {}
+      baseline = null
       persist()
     },
 

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -112,6 +112,7 @@ function createVsmIOStore() {
         createdAt: vsmDataStore.createdAt,
         updatedAt: vsmDataStore.updatedAt,
         readinessOverrides: vsmDataStore.readinessOverrides,
+        dora: vsmDataStore.dora,
       })
     },
 

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -112,6 +112,7 @@ function createVsmIOStore() {
         createdAt: vsmDataStore.createdAt,
         updatedAt: vsmDataStore.updatedAt,
         readinessOverrides: vsmDataStore.readinessOverrides,
+        annotations: vsmDataStore.annotations,
       })
     },
 

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -112,6 +112,7 @@ function createVsmIOStore() {
         createdAt: vsmDataStore.createdAt,
         updatedAt: vsmDataStore.updatedAt,
         readinessOverrides: vsmDataStore.readinessOverrides,
+        baseline: vsmDataStore.baseline,
       })
     },
 

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -1,0 +1,54 @@
+/**
+ * Kaizen-burst annotations
+ *
+ * Pure helpers for tagging improvement opportunities ("kaizen bursts") on steps
+ * and connections, then rolling them up into an improvement backlog grouped by
+ * waste type.
+ */
+
+import { WASTE_TYPES, isWasteType } from '../data/wasteTypes.js'
+
+/**
+ * Create a kaizen annotation.
+ * @param {'step'|'connection'} targetType
+ * @param {string} targetId
+ * @param {string} wasteType - One of WASTE_TYPES (unrecognized → practice_gap)
+ * @param {string} [note]
+ * @returns {{id:string, targetType:string, targetId:string, wasteType:string, note:string, createdAt:string}}
+ */
+export function createAnnotation(targetType, targetId, wasteType, note = '') {
+  return {
+    id: crypto.randomUUID(),
+    targetType,
+    targetId,
+    wasteType: isWasteType(wasteType) ? wasteType : WASTE_TYPES.PRACTICE_GAP,
+    note,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * Group annotations by waste type.
+ * @param {Array} annotations
+ * @returns {Object} waste type -> annotation[]
+ */
+export function groupAnnotationsByWaste(annotations = []) {
+  return annotations.reduce((acc, a) => {
+    if (!acc[a.wasteType]) acc[a.wasteType] = []
+    acc[a.wasteType].push(a)
+    return acc
+  }, {})
+}
+
+/**
+ * Summarize the improvement backlog.
+ * @param {Array} annotations
+ * @returns {{total:number, byWaste:Object}}
+ */
+export function summarizeAnnotations(annotations = []) {
+  const byWaste = annotations.reduce((acc, a) => {
+    acc[a.wasteType] = (acc[a.wasteType] || 0) + 1
+    return acc
+  }, {})
+  return { total: annotations.length, byWaste }
+}

--- a/src/utils/calculations/doraReconciliation.js
+++ b/src/utils/calculations/doraReconciliation.js
@@ -1,0 +1,94 @@
+/**
+ * DORA reconciliation (P1c)
+ *
+ * Captures the four DORA metrics per map and reconciles the VSM-derived lead
+ * time against the actual lead time for changes. The gap between them is the
+ * hidden queue the map does not yet model — the strongest Phase-0 "Assess"
+ * signal that a value stream is incomplete.
+ *
+ * Pure functions. Durations in minutes; rates as 0-100 percentages;
+ * deployment frequency as deploys per (calendar) day.
+ */
+
+import { calculateTotalLeadTime } from './metrics.js'
+
+const ONE_DAY = 1440 // minutes
+const ONE_WEEK = ONE_DAY * 7
+const ONE_MONTH = ONE_DAY * 30
+
+/** A blank DORA record (all metrics unknown). */
+export const emptyDora = () => ({
+  deploymentFrequencyPerDay: null,
+  leadTimeForChangesMinutes: null,
+  changeFailureRatePct: null,
+  mttrMinutes: null,
+})
+
+// Actual lead time within this ratio of the VSM-derived total counts as aligned.
+const ALIGNED_RATIO = 1.5
+
+/**
+ * Reconcile the VSM-derived lead time against the recorded actual lead time.
+ * @param {Array} steps
+ * @param {Object} dora
+ * @returns {{vsmLeadTime:number, actualLeadTime:(number|null), hiddenQueue:number, ratio:(number|null), status:string}}
+ */
+export function reconcileLeadTime(steps = [], dora = emptyDora()) {
+  const vsmLeadTime = calculateTotalLeadTime(steps)
+  const actualLeadTime = dora?.leadTimeForChangesMinutes ?? null
+
+  if (actualLeadTime === null) {
+    return { vsmLeadTime, actualLeadTime: null, hiddenQueue: 0, ratio: null, status: 'unknown' }
+  }
+
+  const hiddenQueue = Math.max(0, actualLeadTime - vsmLeadTime)
+  const ratio = vsmLeadTime > 0 ? actualLeadTime / vsmLeadTime : null
+
+  let status
+  if (actualLeadTime < vsmLeadTime) status = 'optimistic-map'
+  else if (ratio !== null && ratio <= ALIGNED_RATIO) status = 'aligned'
+  else status = 'hidden-queue'
+
+  return { vsmLeadTime, actualLeadTime, hiddenQueue, ratio, status }
+}
+
+const tier = (value, { elite, high, medium }, lowerIsBetter = true) => {
+  if (value === null || value === undefined) return 'unknown'
+  if (lowerIsBetter) {
+    if (value <= elite) return 'elite'
+    if (value <= high) return 'high'
+    if (value <= medium) return 'medium'
+    return 'low'
+  }
+  if (value >= elite) return 'elite'
+  if (value >= high) return 'high'
+  if (value >= medium) return 'medium'
+  return 'low'
+}
+
+/**
+ * Classify each DORA metric into an elite/high/medium/low tier.
+ * Bands follow the DORA "Accelerate" performance clusters.
+ * @param {Object} dora
+ * @returns {{deploymentFrequency:string, leadTimeForChanges:string, changeFailureRate:string, mttr:string}}
+ */
+export function classifyDora(dora = emptyDora()) {
+  return {
+    // deploys per day — higher is better
+    deploymentFrequency: tier(
+      dora.deploymentFrequencyPerDay,
+      { elite: 1, high: 1 / 7, medium: 1 / 30 },
+      false
+    ),
+    // lead time for changes (minutes) — lower is better
+    leadTimeForChanges: tier(dora.leadTimeForChangesMinutes, {
+      elite: ONE_DAY,
+      high: ONE_WEEK,
+      medium: ONE_MONTH,
+    }),
+    // change failure rate (%) — lower is better
+    changeFailureRate: tier(dora.changeFailureRatePct, { elite: 15, high: 20, medium: 30 }),
+    // mttr (minutes) — lower is better
+    mttr: tier(dora.mttrMinutes, { elite: 60, high: ONE_DAY, medium: ONE_WEEK }),
+  }
+}

--- a/src/utils/calculations/futureState.js
+++ b/src/utils/calculations/futureState.js
@@ -1,0 +1,53 @@
+/**
+ * Current-state vs future-state comparison (P3)
+ *
+ * The classic VSM workflow draws a current state, designs an improved future
+ * state, and quantifies the projected improvement. This app captures a baseline
+ * snapshot; the live ("working") map is then improved and compared against it.
+ *
+ * Pure function. Reuses calculateMetrics so the metric definitions are shared.
+ */
+
+import { calculateMetrics } from './metrics.js'
+
+// For each metric: does a higher value mean improvement?
+const HIGHER_IS_BETTER = {
+  totalLeadTime: false,
+  totalProcessTime: false,
+  flowEfficiency: true,
+  firstPassYield: true,
+}
+
+const summarize = (steps, connections) => {
+  const m = calculateMetrics(steps, connections)
+  return {
+    totalLeadTime: m.totalLeadTime,
+    totalProcessTime: m.totalProcessTime,
+    flowEfficiency: m.flowEfficiency.percentage,
+    firstPassYield: m.firstPassYield.percentage,
+  }
+}
+
+const delta = (metric, base, work) => {
+  const d = Number((work - base).toFixed(2))
+  const improved = d === 0 ? false : HIGHER_IS_BETTER[metric] ? d > 0 : d < 0
+  return { baseline: base, working: work, delta: d, improved }
+}
+
+/**
+ * Compare a baseline state against a working state.
+ * @returns {Object|null} null when there is no baseline to compare against
+ */
+export function compareStates(baselineSteps, baselineConnections, workingSteps, workingConnections) {
+  if (!baselineSteps) return null
+
+  const baseline = summarize(baselineSteps, baselineConnections || [])
+  const working = summarize(workingSteps || [], workingConnections || [])
+
+  const deltas = Object.keys(HIGHER_IS_BETTER).reduce((acc, metric) => {
+    acc[metric] = delta(metric, baseline[metric], working[metric])
+    return acc
+  }, {})
+
+  return { baseline, working, deltas }
+}

--- a/src/utils/calculations/littlesLaw.js
+++ b/src/utils/calculations/littlesLaw.js
@@ -1,0 +1,51 @@
+/**
+ * WIP & batch-size levers via Little's Law (P2)
+ *
+ * Little's Law: WIP = throughput × lead time. Batch size is the primary lever:
+ * smaller batches shrink the queueing (wait) portion of lead time. These pure
+ * functions let the simulator/dashboard project "what if we halve the batch?".
+ *
+ * Durations in minutes; throughput in items per (work) day.
+ */
+
+const MINUTES_PER_WORK_DAY = 480
+
+/**
+ * Estimate work in progress from Little's Law.
+ * @param {number} throughputPerDay - Completed items per work day
+ * @param {number} leadTimeMinutes - Lead time per item (minutes)
+ * @param {number} [minutesPerDay]
+ * @returns {number} Items in progress
+ */
+export function wipFromLittlesLaw(throughputPerDay, leadTimeMinutes, minutesPerDay = MINUTES_PER_WORK_DAY) {
+  if (!throughputPerDay || throughputPerDay <= 0) return 0
+  const leadTimeDays = (leadTimeMinutes || 0) / minutesPerDay
+  return Number((throughputPerDay * leadTimeDays).toFixed(2))
+}
+
+/**
+ * Project the lead-time impact of changing a step's batch size.
+ *
+ * Model: lead time = process time + wait time. Wait time scales linearly with
+ * batch size (smaller batches queue less), so projectedWait = wait × (new/current).
+ *
+ * @param {{processTime:number, leadTime:number, batchSize:number}} step
+ * @param {number} newBatchSize
+ * @returns {{newBatchSize:number, currentLeadTime:number, projectedLeadTime:number, deltaMinutes:number, deltaPercent:number}}
+ */
+export function projectBatchSizeChange(step, newBatchSize) {
+  const processTime = step.processTime || 0
+  const currentLeadTime = step.leadTime || 0
+  const currentBatch = step.batchSize && step.batchSize > 0 ? step.batchSize : 1
+  const batch = Math.max(1, Math.floor(newBatchSize) || 1)
+
+  const waitTime = Math.max(0, currentLeadTime - processTime)
+  const projectedWait = waitTime * (batch / currentBatch)
+  const projectedLeadTime = Math.round(processTime + projectedWait)
+
+  const deltaMinutes = projectedLeadTime - currentLeadTime
+  const deltaPercent =
+    currentLeadTime > 0 ? Number(((deltaMinutes / currentLeadTime) * 100).toFixed(1)) : 0
+
+  return { newBatchSize: batch, currentLeadTime, projectedLeadTime, deltaMinutes, deltaPercent }
+}

--- a/src/utils/calculations/recommendations.js
+++ b/src/utils/calculations/recommendations.js
@@ -1,0 +1,57 @@
+/**
+ * Constraint → countermeasure recommendations (P2)
+ *
+ * Turns detected CD-readiness gaps into prescriptive, deep-linked countermeasures,
+ * prioritizing the gaps that sit on the flow constraint (Theory of Constraints:
+ * fix the bottleneck first).
+ *
+ * Iterative framing — recommendations point at practices/constraints, never a
+ * single migration phase (beyond.minimumcd.org phases run simultaneously).
+ *
+ * Pure function. Consumes the output of calculateCdReadiness, so the inference
+ * logic is not duplicated here.
+ */
+
+/** Prescriptive countermeasure per readiness item id. */
+const COUNTERMEASURES = {
+  'work-decomposition': 'Slice work so each item completes within two days; integrate sooner.',
+  'testing-fundamentals':
+    'Re-architect the test suite to run in under 10 minutes — parallelize and replace slow dependencies.',
+  'wip-limits': 'Set an explicit WIP limit on this step so it acts as a flow governor.',
+  'small-batches': 'Reduce batch size; integrate and release smaller increments.',
+  'single-path-to-production':
+    'Automate one path to production and remove manual or duplicate deployment steps.',
+  'continuous-integration': 'Integrate to trunk at least daily behind automated tests.',
+  'definition-of-deployable':
+    'Define automated "definition of deployable" criteria so work does not bounce back.',
+  rollback: 'Add an automated rollback path that recovers production within minutes.',
+}
+
+const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 }
+
+/**
+ * Generate prioritized countermeasure recommendations from readiness gaps.
+ * @param {Array} readinessItems - Output of calculateCdReadiness
+ * @param {string[]} [bottleneckStepIds] - Step ids flagged as the constraint
+ * @returns {Array} Recommendations sorted constraint-first
+ */
+export function generateRecommendations(readinessItems = [], bottleneckStepIds = []) {
+  const onConstraint = new Set(bottleneckStepIds)
+
+  const recs = readinessItems
+    .filter((item) => item.status === 'gap' && COUNTERMEASURES[item.id])
+    .map((item) => ({
+      id: item.id,
+      title: item.label,
+      finding: item.explanation,
+      countermeasure: COUNTERMEASURES[item.id],
+      link: item.link,
+      targetStepId: item.stepId ?? null,
+      priority: item.stepId && onConstraint.has(item.stepId) ? 'high' : 'medium',
+    }))
+
+  return recs.sort((a, b) => {
+    const byPriority = PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]
+    return byPriority !== 0 ? byPriority : a.title.localeCompare(b.title)
+  })
+}

--- a/src/utils/calculations/waitTime.js
+++ b/src/utils/calculations/waitTime.js
@@ -1,0 +1,68 @@
+/**
+ * Wait-time waterfall (P1a)
+ *
+ * Splits each step's lead time into value-add (process) time and wait time,
+ * surfacing the hidden queues that dominate most value streams. Manual steps
+ * are flagged as handoffs — Phase 2 of beyond.minimumcd.org names manual gates
+ * and handoff delays as waste.
+ *
+ * Pure functions; all times in minutes.
+ */
+
+import { isAutomated } from '../../models/StepFactory.js'
+import { WAIT_DOMINATED_THRESHOLD } from '../../data/thresholds.js'
+
+/**
+ * @typedef {Object} WaitRow
+ * @property {string} stepId
+ * @property {string} name
+ * @property {number} processTime - Value-add minutes
+ * @property {number} waitTime - Wait minutes (leadTime - processTime, floored at 0)
+ * @property {number} leadTime
+ * @property {number} waitPercentage - Wait as a % of lead time (0 when leadTime is 0)
+ * @property {boolean} waitDominated - Wait percentage at/above the threshold
+ * @property {boolean} manual - Step is a manual handoff (a hidden queue)
+ */
+
+const waitPct = (waitTime, leadTime) => (leadTime > 0 ? (waitTime / leadTime) * 100 : 0)
+
+/**
+ * Break a value stream down into per-step value-add vs. wait time, with totals.
+ * @param {Array} steps
+ * @returns {{steps: WaitRow[], totals: {processTime:number, waitTime:number, leadTime:number, waitPercentage:number}}}
+ */
+export function calculateWaitTimeBreakdown(steps = []) {
+  const rows = steps.map((s) => {
+    const processTime = s.processTime || 0
+    const leadTime = s.leadTime || 0
+    const waitTime = Math.max(0, leadTime - processTime)
+    const percentage = waitPct(waitTime, leadTime)
+    return {
+      stepId: s.id,
+      name: s.name,
+      processTime,
+      waitTime,
+      leadTime,
+      waitPercentage: Number(percentage.toFixed(1)),
+      waitDominated: percentage >= WAIT_DOMINATED_THRESHOLD,
+      manual: !isAutomated(s),
+    }
+  })
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      processTime: acc.processTime + r.processTime,
+      waitTime: acc.waitTime + r.waitTime,
+      leadTime: acc.leadTime + r.leadTime,
+    }),
+    { processTime: 0, waitTime: 0, leadTime: 0 }
+  )
+
+  return {
+    steps: rows,
+    totals: {
+      ...totals,
+      waitPercentage: Number(waitPct(totals.waitTime, totals.leadTime).toFixed(1)),
+    },
+  }
+}

--- a/src/utils/simulation/monteCarlo.js
+++ b/src/utils/simulation/monteCarlo.js
@@ -1,0 +1,85 @@
+/**
+ * Monte-Carlo lead-time simulation (P3)
+ *
+ * Real value streams have variability: the same step takes different amounts of
+ * time on different items, and high utilization turns that variability into
+ * queues. This module samples each step's lead time across many trials to
+ * produce a *distribution* of total lead time (P50/P85/P95) rather than a single
+ * deterministic number.
+ *
+ * Uses a seeded RNG so results are reproducible and testable.
+ */
+
+/**
+ * Deterministic PRNG (mulberry32). Returns a function yielding floats in [0, 1).
+ * @param {number} seed
+ * @returns {() => number}
+ */
+export function createSeededRng(seed) {
+  let a = seed >>> 0
+  return function rng() {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * The percentile value of a numeric sample (nearest-rank on sorted ascending).
+ * @param {number[]} values
+ * @param {number} p - 0..100
+ * @returns {number}
+ */
+export function percentile(values, p) {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((x, y) => x - y)
+  const rank = Math.ceil((p / 100) * sorted.length)
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1))
+  return sorted[index]
+}
+
+/**
+ * Sample a step's lead time using a symmetric triangular distribution centred on
+ * the recorded lead time with half-width = leadTime * variability.
+ * Triangular = average of two uniforms, which concentrates mass near the centre.
+ */
+function sampleLeadTime(leadTime, variability, rng) {
+  if (variability <= 0) return leadTime
+  const triangular = (rng() + rng()) / 2 // 0..1, peak at 0.5
+  const factor = 1 + (triangular * 2 - 1) * variability
+  return Math.max(0, leadTime * factor)
+}
+
+/**
+ * Run a Monte-Carlo simulation of total lead time.
+ * @param {Array} steps
+ * @param {{trials?:number, variability?:number, seed?:number}} [options]
+ *   variability is a coefficient (0 = deterministic, 0.3 = ±30%).
+ * @returns {{samples:number[], p50:number, p85:number, p95:number, mean:number}}
+ */
+export function runMonteCarlo(steps = [], options = {}) {
+  const { trials = 1000, variability = 0.25, seed = 1 } = options
+  const rng = createSeededRng(seed)
+
+  const samples = []
+  for (let trial = 0; trial < trials; trial++) {
+    let total = 0
+    for (const step of steps) {
+      total += sampleLeadTime(step.leadTime || 0, variability, rng)
+    }
+    samples.push(Math.round(total))
+  }
+
+  const mean =
+    samples.length > 0 ? Math.round(samples.reduce((sum, v) => sum + v, 0) / samples.length) : 0
+
+  return {
+    samples,
+    p50: percentile(samples, 50),
+    p85: percentile(samples, 85),
+    p95: percentile(samples, 95),
+    mean,
+  }
+}

--- a/src/utils/validation/vsmValidator.js
+++ b/src/utils/validation/vsmValidator.js
@@ -128,5 +128,9 @@ export function sanitizeVSMData(data) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    dora:
+      data.dora && typeof data.dora === 'object' && !Array.isArray(data.dora)
+        ? data.dora
+        : undefined,
   }
 }

--- a/src/utils/validation/vsmValidator.js
+++ b/src/utils/validation/vsmValidator.js
@@ -128,5 +128,7 @@ export function sanitizeVSMData(data) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    baseline:
+      data.baseline && typeof data.baseline === 'object' ? data.baseline : undefined,
   }
 }

--- a/src/utils/validation/vsmValidator.js
+++ b/src/utils/validation/vsmValidator.js
@@ -128,5 +128,6 @@ export function sanitizeVSMData(data) {
       data.readinessOverrides && typeof data.readinessOverrides === 'object'
         ? data.readinessOverrides
         : {},
+    annotations: Array.isArray(data.annotations) ? data.annotations : undefined,
   }
 }

--- a/tests/unit/calculations/doraReconciliation.test.js
+++ b/tests/unit/calculations/doraReconciliation.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  reconcileLeadTime,
+  classifyDora,
+  emptyDora,
+} from '../../../src/utils/calculations/doraReconciliation'
+
+const step = (leadTime) => ({ id: 'x', name: 'S', processTime: 30, leadTime })
+
+describe('reconcileLeadTime', () => {
+  it('is unknown when no actual lead time is recorded', () => {
+    const r = reconcileLeadTime([step(240)], emptyDora())
+    expect(r.status).toBe('unknown')
+  })
+
+  it('flags a hidden queue when actual lead time far exceeds the VSM-derived total', () => {
+    const r = reconcileLeadTime([step(480)], { ...emptyDora(), leadTimeForChangesMinutes: 4800 })
+    expect(r.vsmLeadTime).toBe(480)
+    expect(r.actualLeadTime).toBe(4800)
+    expect(r.hiddenQueue).toBe(4320)
+    expect(r.status).toBe('hidden-queue')
+  })
+
+  it('reports aligned when actual and VSM lead times are close', () => {
+    const r = reconcileLeadTime([step(1000)], { ...emptyDora(), leadTimeForChangesMinutes: 1100 })
+    expect(r.status).toBe('aligned')
+    expect(r.hiddenQueue).toBe(100)
+  })
+
+  it('reports an optimistic map when actual is below the VSM-derived total', () => {
+    const r = reconcileLeadTime([step(1000)], { ...emptyDora(), leadTimeForChangesMinutes: 500 })
+    expect(r.status).toBe('optimistic-map')
+    expect(r.hiddenQueue).toBe(0)
+  })
+})
+
+describe('classifyDora', () => {
+  it('returns unknown tiers for an empty record', () => {
+    const tiers = classifyDora(emptyDora())
+    expect(tiers.leadTimeForChanges).toBe('unknown')
+    expect(tiers.deploymentFrequency).toBe('unknown')
+    expect(tiers.changeFailureRate).toBe('unknown')
+    expect(tiers.mttr).toBe('unknown')
+  })
+
+  it('classifies elite performance', () => {
+    const tiers = classifyDora({
+      deploymentFrequencyPerDay: 5,
+      leadTimeForChangesMinutes: 600,
+      changeFailureRatePct: 10,
+      mttrMinutes: 30,
+    })
+    expect(tiers.deploymentFrequency).toBe('elite')
+    expect(tiers.leadTimeForChanges).toBe('elite')
+    expect(tiers.changeFailureRate).toBe('elite')
+    expect(tiers.mttr).toBe('elite')
+  })
+
+  it('classifies low performance', () => {
+    const tiers = classifyDora({
+      deploymentFrequencyPerDay: 0.01,
+      leadTimeForChangesMinutes: 60000,
+      changeFailureRatePct: 45,
+      mttrMinutes: 20000,
+    })
+    expect(tiers.deploymentFrequency).toBe('low')
+    expect(tiers.leadTimeForChanges).toBe('low')
+    expect(tiers.changeFailureRate).toBe('low')
+    expect(tiers.mttr).toBe('low')
+  })
+})

--- a/tests/unit/calculations/futureState.test.js
+++ b/tests/unit/calculations/futureState.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { compareStates } from '../../../src/utils/calculations/futureState'
+
+const baseline = [
+  { id: 'a', name: 'Dev', processTime: 60, leadTime: 600, percentCompleteAccurate: 80 },
+]
+// Working state: same work, less waiting (lead time halved)
+const working = [
+  { id: 'a', name: 'Dev', processTime: 60, leadTime: 300, percentCompleteAccurate: 80 },
+]
+
+describe('compareStates', () => {
+  it('reports baseline and working metrics side by side', () => {
+    const result = compareStates(baseline, [], working, [])
+    expect(result.baseline.totalLeadTime).toBe(600)
+    expect(result.working.totalLeadTime).toBe(300)
+  })
+
+  it('computes the lead-time delta and improvement direction', () => {
+    const result = compareStates(baseline, [], working, [])
+    expect(result.deltas.totalLeadTime.delta).toBe(-300)
+    expect(result.deltas.totalLeadTime.improved).toBe(true)
+  })
+
+  it('marks flow efficiency as improved when it rises', () => {
+    const result = compareStates(baseline, [], working, [])
+    // base efficiency 60/600 = 10%, working 60/300 = 20%
+    expect(result.deltas.flowEfficiency.delta).toBeGreaterThan(0)
+    expect(result.deltas.flowEfficiency.improved).toBe(true)
+  })
+
+  it('reports no change when states are identical', () => {
+    const result = compareStates(baseline, [], baseline, [])
+    expect(result.deltas.totalLeadTime.delta).toBe(0)
+    expect(result.deltas.totalLeadTime.improved).toBe(false)
+  })
+
+  it('handles a missing baseline by returning null', () => {
+    expect(compareStates(null, null, working, [])).toBeNull()
+  })
+})

--- a/tests/unit/calculations/littlesLaw.test.js
+++ b/tests/unit/calculations/littlesLaw.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  wipFromLittlesLaw,
+  projectBatchSizeChange,
+} from '../../../src/utils/calculations/littlesLaw'
+
+describe('wipFromLittlesLaw', () => {
+  it('computes WIP = throughput x lead time (in days)', () => {
+    // 2 items/day, lead time 2 work days (960 min) => 4 items in progress
+    expect(wipFromLittlesLaw(2, 960)).toBe(4)
+  })
+
+  it('returns 0 when throughput is missing', () => {
+    expect(wipFromLittlesLaw(null, 960)).toBe(0)
+  })
+})
+
+describe('projectBatchSizeChange', () => {
+  const step = { processTime: 60, leadTime: 240, batchSize: 4 }
+
+  it('shrinks the wait portion proportionally to the batch reduction', () => {
+    // wait = 180; halving batch (4 -> 2) halves wait to 90; lead = 60 + 90 = 150
+    const result = projectBatchSizeChange(step, 2)
+    expect(result.projectedLeadTime).toBe(150)
+    expect(result.deltaMinutes).toBe(-90)
+  })
+
+  it('reports the percent change', () => {
+    const result = projectBatchSizeChange(step, 2)
+    expect(result.deltaPercent).toBe(-37.5)
+  })
+
+  it('never drops below process time and clamps batch to at least 1', () => {
+    const result = projectBatchSizeChange({ processTime: 60, leadTime: 240, batchSize: 4 }, 0)
+    expect(result.newBatchSize).toBe(1)
+    expect(result.projectedLeadTime).toBeGreaterThanOrEqual(60)
+  })
+
+  it('increases lead time when batch size grows', () => {
+    const result = projectBatchSizeChange(step, 8)
+    expect(result.projectedLeadTime).toBeGreaterThan(step.leadTime)
+    expect(result.deltaMinutes).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/calculations/recommendations.test.js
+++ b/tests/unit/calculations/recommendations.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { generateRecommendations } from '../../../src/utils/calculations/recommendations'
+
+const item = (o) => ({
+  id: 'work-decomposition',
+  label: 'Work Decomposition',
+  kind: 'signal',
+  status: 'gap',
+  stepId: 's1',
+  explanation: 'too big',
+  link: 'https://beyond.minimumcd.org/x',
+  ...o,
+})
+
+describe('generateRecommendations', () => {
+  it('returns no recommendations when there are no gaps', () => {
+    const recs = generateRecommendations([item({ status: 'met' })], [])
+    expect(recs).toEqual([])
+  })
+
+  it('creates a deep-linked countermeasure for each gap', () => {
+    const recs = generateRecommendations([item()], [])
+    expect(recs).toHaveLength(1)
+    expect(recs[0].title).toBe('Work Decomposition')
+    expect(recs[0].countermeasure).toMatch(/two days|slice/i)
+    expect(recs[0].link).toMatch(/beyond\.minimumcd\.org/)
+    expect(recs[0].targetStepId).toBe('s1')
+  })
+
+  it('ignores items with no defined countermeasure (e.g. unknown ids)', () => {
+    const recs = generateRecommendations([item({ id: 'mystery', status: 'gap' })], [])
+    expect(recs).toEqual([])
+  })
+
+  it('prioritizes recommendations on the constraint (bottleneck) first', () => {
+    const recs = generateRecommendations(
+      [
+        item({ id: 'work-decomposition', label: 'Work Decomposition', stepId: 's1' }),
+        item({ id: 'wip-limits', label: 'Work In Progress Limits', stepId: 'bottleneck' }),
+      ],
+      ['bottleneck']
+    )
+    expect(recs[0].id).toBe('wip-limits')
+    expect(recs[0].priority).toBe('high')
+    expect(recs[1].priority).toBe('medium')
+  })
+
+  it('does not assign a single migration phase', () => {
+    const recs = generateRecommendations([item()], [])
+    const text = `${recs[0].finding} ${recs[0].countermeasure}`
+    expect(/phase \d/i.test(text)).toBe(false)
+  })
+})

--- a/tests/unit/calculations/waitTime.test.js
+++ b/tests/unit/calculations/waitTime.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { calculateWaitTimeBreakdown } from '../../../src/utils/calculations/waitTime'
+
+const step = (o) => ({
+  id: 'x',
+  name: 'Step',
+  type: 'development',
+  processTime: 60,
+  leadTime: 240,
+  automated: true,
+  ...o,
+})
+
+describe('calculateWaitTimeBreakdown', () => {
+  it('returns no rows for an empty stream', () => {
+    const result = calculateWaitTimeBreakdown([])
+    expect(result.steps).toEqual([])
+    expect(result.totals.leadTime).toBe(0)
+  })
+
+  it('splits each step into value-add and wait time', () => {
+    const row = calculateWaitTimeBreakdown([step({ id: 'a', processTime: 60, leadTime: 240 })]).steps[0]
+    expect(row.processTime).toBe(60)
+    expect(row.waitTime).toBe(180)
+    expect(row.waitPercentage).toBe(75)
+  })
+
+  it('never reports negative wait when process exceeds lead time', () => {
+    const row = calculateWaitTimeBreakdown([step({ processTime: 100, leadTime: 60 })]).steps[0]
+    expect(row.waitTime).toBe(0)
+    expect(row.waitPercentage).toBe(0)
+  })
+
+  it('flags a wait-dominated step as a hidden queue', () => {
+    const row = calculateWaitTimeBreakdown([step({ processTime: 10, leadTime: 200 })]).steps[0]
+    expect(row.waitDominated).toBe(true)
+  })
+
+  it('does not flag a value-add-dominated step', () => {
+    const row = calculateWaitTimeBreakdown([step({ processTime: 180, leadTime: 200 })]).steps[0]
+    expect(row.waitDominated).toBe(false)
+  })
+
+  it('flags a manual step as a handoff', () => {
+    const row = calculateWaitTimeBreakdown([step({ automated: false })]).steps[0]
+    expect(row.manual).toBe(true)
+  })
+
+  it('treats a step with no automated property as automated (not a handoff)', () => {
+    const s = step({})
+    delete s.automated
+    expect(calculateWaitTimeBreakdown([s]).steps[0].manual).toBe(false)
+  })
+
+  it('totals process, wait, and lead time across steps', () => {
+    const { totals } = calculateWaitTimeBreakdown([
+      step({ id: 'a', processTime: 60, leadTime: 240 }),
+      step({ id: 'b', processTime: 40, leadTime: 160 }),
+    ])
+    expect(totals.processTime).toBe(100)
+    expect(totals.waitTime).toBe(300)
+    expect(totals.leadTime).toBe(400)
+    expect(totals.waitPercentage).toBe(75)
+  })
+})

--- a/tests/unit/simulation/monteCarlo.test.js
+++ b/tests/unit/simulation/monteCarlo.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createSeededRng,
+  runMonteCarlo,
+  percentile,
+} from '../../../src/utils/simulation/monteCarlo'
+
+const steps = [
+  { id: 'a', name: 'A', processTime: 60, leadTime: 240 },
+  { id: 'b', name: 'B', processTime: 30, leadTime: 120 },
+]
+
+describe('createSeededRng', () => {
+  it('is deterministic for a given seed', () => {
+    const r1 = createSeededRng(42)
+    const r2 = createSeededRng(42)
+    expect(r1()).toBe(r2())
+    expect(r1()).toBe(r2())
+  })
+
+  it('produces values in [0, 1)', () => {
+    const rng = createSeededRng(7)
+    for (let i = 0; i < 100; i++) {
+      const v = rng()
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThan(1)
+    }
+  })
+})
+
+describe('percentile', () => {
+  it('returns the value at the requested percentile', () => {
+    expect(percentile([10, 20, 30, 40, 50], 50)).toBe(30)
+    expect(percentile([10, 20, 30, 40, 50], 100)).toBe(50)
+  })
+})
+
+describe('runMonteCarlo', () => {
+  it('returns the deterministic total when variability is zero', () => {
+    const result = runMonteCarlo(steps, { trials: 100, variability: 0, seed: 1 })
+    expect(result.p50).toBe(360)
+    expect(result.p85).toBe(360)
+    expect(result.mean).toBe(360)
+  })
+
+  it('produces an increasing percentile spread under variability', () => {
+    const result = runMonteCarlo(steps, { trials: 500, variability: 0.3, seed: 1 })
+    expect(result.p50).toBeLessThanOrEqual(result.p85)
+    expect(result.p85).toBeLessThanOrEqual(result.p95)
+    expect(result.samples).toHaveLength(500)
+  })
+
+  it('is reproducible for the same seed', () => {
+    const a = runMonteCarlo(steps, { trials: 200, variability: 0.4, seed: 99 })
+    const b = runMonteCarlo(steps, { trials: 200, variability: 0.4, seed: 99 })
+    expect(a.p85).toBe(b.p85)
+    expect(a.mean).toBe(b.mean)
+  })
+
+  it('handles an empty stream', () => {
+    const result = runMonteCarlo([], { trials: 10, variability: 0.2, seed: 1 })
+    expect(result.p50).toBe(0)
+    expect(result.samples).toHaveLength(10)
+  })
+})

--- a/tests/unit/utils/annotations.test.js
+++ b/tests/unit/utils/annotations.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createAnnotation,
+  groupAnnotationsByWaste,
+  summarizeAnnotations,
+} from '../../../src/utils/annotations'
+import { WASTE_TYPES } from '../../../src/data/wasteTypes'
+
+describe('createAnnotation', () => {
+  it('builds an annotation with an id and the given fields', () => {
+    const a = createAnnotation('step', 's1', WASTE_TYPES.WAITING, 'Long queue here')
+    expect(a.id).toBeTruthy()
+    expect(a.targetType).toBe('step')
+    expect(a.targetId).toBe('s1')
+    expect(a.wasteType).toBe(WASTE_TYPES.WAITING)
+    expect(a.note).toBe('Long queue here')
+    expect(a.createdAt).toBeTruthy()
+  })
+
+  it('defaults an unrecognized waste type to practice_gap', () => {
+    const a = createAnnotation('step', 's1', 'nonsense', '')
+    expect(a.wasteType).toBe(WASTE_TYPES.PRACTICE_GAP)
+  })
+})
+
+describe('groupAnnotationsByWaste', () => {
+  it('groups annotations by their waste type', () => {
+    const annotations = [
+      createAnnotation('step', 's1', WASTE_TYPES.WAITING, 'a'),
+      createAnnotation('step', 's2', WASTE_TYPES.WAITING, 'b'),
+      createAnnotation('connection', 'c1', WASTE_TYPES.REWORK, 'c'),
+    ]
+    const grouped = groupAnnotationsByWaste(annotations)
+    expect(grouped[WASTE_TYPES.WAITING]).toHaveLength(2)
+    expect(grouped[WASTE_TYPES.REWORK]).toHaveLength(1)
+    expect(grouped[WASTE_TYPES.HANDOFF]).toBeUndefined()
+  })
+})
+
+describe('summarizeAnnotations', () => {
+  it('counts total annotations and distinct waste types', () => {
+    const annotations = [
+      createAnnotation('step', 's1', WASTE_TYPES.WAITING, 'a'),
+      createAnnotation('step', 's2', WASTE_TYPES.WAITING, 'b'),
+      createAnnotation('connection', 'c1', WASTE_TYPES.REWORK, 'c'),
+    ]
+    const summary = summarizeAnnotations(annotations)
+    expect(summary.total).toBe(3)
+    expect(summary.byWaste[WASTE_TYPES.WAITING]).toBe(2)
+    expect(summary.byWaste[WASTE_TYPES.REWORK]).toBe(1)
+  })
+
+  it('handles an empty backlog', () => {
+    expect(summarizeAnnotations([])).toEqual({ total: 0, byWaste: {} })
+  })
+})


### PR DESCRIPTION
## What

A single **integration branch** that combines all 7 CD Readiness Diagnosis features + the import design doc into one conflict-free, green merge — so the suite can land in one shot instead of rebasing 8 PRs against each other.

Combines:
- #4 Wait-time waterfall (P1a)
- #5 DORA reconciliation (P1c)
- #6 Kaizen-burst annotations
- #7 Constraint → countermeasure recommendations (P2)
- #8 WIP & batch levers / Little's Law (P2)
- #9 Monte-Carlo lead time (P3)
- #10 Current vs future state (P3)
- #11 Real-tooling import design doc (P3)

## Conflict resolution

All conflicts were in the shared integration points and resolved by **combining** (not choosing):
- **`App.svelte`** — all six new panels imported and mounted below the metrics dashboard.
- **Persisted-state plumbing** (`vsmDataStore`, `vsmValidator`, `VsmJsonRepository`, `vsmIOStore`, cucumber `testStores`) — the three new per-map fields (`dora`, `annotations`, `baseline`) are all threaded through `persist` / `loadMap` / `createNewMap` / `clearMap` / sanitize / JSON round-trip, and the Kaizen `deleteStep`/`deleteConnection` annotation-pruning is preserved.

## Verification

Full gate green on the integrated branch:
- **470 unit tests** pass
- **build** succeeds
- **lint** clean
- **459 acceptance scenarios** pass (the ~201 "undefined" are pre-existing feature files unrelated to this work)

## Merge guidance

Merging **this** PR delivers the whole suite at once. The 8 individual PRs (#4–#11) can then be closed as superseded — or, if you prefer granular review, review them individually and merge this branch as the integration vehicle. Your call.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_