### PR TITLE
Add current-state importer: event log → VSM (P3 / PR-A)

### DIFF
--- a/docs/specs/real-tooling-import.md
+++ b/docs/specs/real-tooling-import.md
@@ -1,10 +1,11 @@
 # Design: Import Current-State from Real Tooling (P3)
 
-> **Status: design only.** This PR contains no runtime code. Live Jira/GitHub/CI
-> integration needs external systems and credentials that are not reachable in
-> the build sandbox, so it cannot ship as working, tested code here. This document
-> specifies the adapter interface and a file-based importer so the live adapters
-> can be added later behind a stable contract.
+> **Status: PR-A implemented; live adapters still design-only.** The pure
+> `deriveVsmFromEvents` engine and the file-based CSV/JSON adapters now ship and
+> are tested (`src/utils/import/`, wired via `vsmIOStore.importEventLog`). The
+> live Jira/GitHub/CI adapters remain design-only — they need external systems
+> and credentials not reachable in the build sandbox — and plug into the same
+> `WorkItemEvent` contract described below.
 
 ## Intent
 

--- a/features/data/import-event-log.feature
+++ b/features/data/import-event-log.feature
@@ -1,0 +1,32 @@
+Feature: Import Current State from an Event Log
+  As a team facilitator
+  I want to import a real event log from my tooling
+  So that the value stream is measured from actual timestamps, not guesses
+
+  Scenario: Import a CSV event log into a value stream
+    Given the following CSV event log:
+      | workItemId | stage | enteredAt            | exitedAt             |
+      | 1          | Dev   | 2026-01-01T09:00:00Z | 2026-01-01T10:00:00Z |
+      | 1          | Test  | 2026-01-01T10:00:00Z | 2026-01-01T10:30:00Z |
+      | 2          | Dev   | 2026-01-01T09:00:00Z | 2026-01-01T11:00:00Z |
+      | 2          | Test  | 2026-01-01T11:00:00Z | 2026-01-01T11:30:00Z |
+    When I import the event log as "csv"
+    Then the imported map has steps "Dev, Test"
+    And the "Test" step is a testing step
+
+  Scenario: Rework in the event log becomes a rework connection
+    Given the following CSV event log:
+      | workItemId | stage | enteredAt            | exitedAt             |
+      | 1          | Dev   | 2026-01-01T09:00:00Z | 2026-01-01T10:00:00Z |
+      | 1          | Test  | 2026-01-01T10:00:00Z | 2026-01-01T10:30:00Z |
+      | 1          | Dev   | 2026-01-01T10:30:00Z | 2026-01-01T11:00:00Z |
+      | 2          | Dev   | 2026-01-01T09:00:00Z | 2026-01-01T10:00:00Z |
+      | 2          | Test  | 2026-01-01T10:00:00Z | 2026-01-01T10:30:00Z |
+    When I import the event log as "csv"
+    Then the imported map has a rework connection
+
+  Scenario: An empty event log is rejected
+    Given the following CSV event log:
+      | workItemId | stage | enteredAt |
+    When I import the event log as "csv"
+    Then the import is rejected

--- a/features/step-definitions/helpers/testStores.js
+++ b/features/step-definitions/helpers/testStores.js
@@ -10,6 +10,8 @@ import { calculateMetrics } from '../../../src/utils/calculations/metrics.js'
 import { calculateCdReadiness } from '../../../src/utils/calculations/cdReadiness.js'
 import { emptyDora } from '../../../src/utils/calculations/doraReconciliation.js'
 import { createAnnotation } from '../../../src/utils/annotations.js'
+import { deriveVsmFromEvents } from '../../../src/utils/import/deriveVsm.js'
+import { parseEventsFromCsv, parseEventsFromJson } from '../../../src/utils/import/eventAdapters.js'
 import { EXAMPLE_MAP } from '../../../src/data/exampleMaps.js'
 // MAP_TEMPLATES is available if needed for template loading tests
 
@@ -377,6 +379,24 @@ function createTestVsmIOStore(dataStore) {
         console.warn('Failed to import JSON:', e)
         return false
       }
+    },
+
+    importEventLog(rawData, format, options = {}) {
+      const events =
+        format === 'csv' ? parseEventsFromCsv(rawData) : parseEventsFromJson(rawData)
+      const { steps, connections } = deriveVsmFromEvents(events, options)
+      if (steps.length === 0) return false
+      const now = new Date().toISOString()
+      dataStore.loadMap({
+        id: crypto.randomUUID(),
+        name: options.name || 'Imported current state',
+        description: 'Derived from a real-tooling event log',
+        steps,
+        connections,
+        createdAt: now,
+        updatedAt: now,
+      })
+      return true
     },
   }
 }

--- a/features/step-definitions/importEventLog.steps.js
+++ b/features/step-definitions/importEventLog.steps.js
@@ -1,0 +1,32 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { vsmDataStore, vsmIOStore } from './helpers/testStores.js'
+
+Given('the following CSV event log:', function (dataTable) {
+  this.eventLogCsv = dataTable
+    .raw()
+    .map((row) => row.join(','))
+    .join('\n')
+})
+
+When('I import the event log as {string}', function (format) {
+  this.importResult = vsmIOStore.importEventLog(this.eventLogCsv, format)
+})
+
+Then('the imported map has steps {string}', function (names) {
+  const expected = names.split(',').map((n) => n.trim())
+  expect(vsmDataStore.steps.map((s) => s.name)).to.deep.equal(expected)
+})
+
+Then('the {string} step is a testing step', function (name) {
+  const step = vsmDataStore.steps.find((s) => s.name === name)
+  expect(step.type).to.equal('testing')
+})
+
+Then('the imported map has a rework connection', function () {
+  expect(vsmDataStore.connections.some((c) => c.type === 'rework')).to.equal(true)
+})
+
+Then('the import is rejected', function () {
+  expect(this.importResult).to.equal(false)
+})

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,6 +15,7 @@
   import DoraPanel from './components/metrics/DoraPanel.svelte'
   import AnnotationsPanel from './components/metrics/AnnotationsPanel.svelte'
   import FutureStatePanel from './components/metrics/FutureStatePanel.svelte'
+  import ImportEventLog from './components/io/ImportEventLog.svelte'
   import WelcomeScreen from './components/ui/WelcomeScreen.svelte'
   import EditorPanel from './components/ui/EditorPanel.svelte'
   import SimulationPanel from './components/ui/SimulationPanel.svelte'
@@ -109,6 +110,7 @@
           <DoraPanel />
           <AnnotationsPanel />
           <FutureStatePanel />
+          <ImportEventLog />
         </main>
         <EditorPanel
           {selectedStepId}

--- a/src/components/io/ImportEventLog.svelte
+++ b/src/components/io/ImportEventLog.svelte
@@ -1,0 +1,65 @@
+<script>
+  import { vsmIOStore } from '../../stores/vsmIOStore.svelte.js'
+
+  let format = $state('csv')
+  let rawData = $state('')
+  let message = $state(null)
+
+  const placeholder = `workItemId,stage,enteredAt,exitedAt
+1,Dev,2026-01-01T09:00:00Z,2026-01-01T11:00:00Z
+1,Test,2026-01-01T11:00:00Z,2026-01-01T11:20:00Z`
+
+  function handleImport() {
+    const ok = vsmIOStore.importEventLog(rawData, format)
+    message = ok
+      ? { kind: 'ok', text: 'Imported current state from the event log.' }
+      : { kind: 'error', text: 'No events could be parsed — check the format.' }
+  }
+</script>
+
+<details class="bg-white border-t border-gray-200 px-6 py-4" data-testid="import-event-log" open>
+  <summary class="cursor-pointer text-sm font-semibold text-gray-800">
+    Import Current State (event log)
+  </summary>
+
+  <p class="mt-2 text-xs text-gray-500">
+    Paste an exported event log (one row per work-item state transition) to derive a measured
+    value stream instead of guessing.
+  </p>
+
+  <div class="mt-2 flex items-center gap-4 text-xs">
+    <label class="flex items-center gap-1">
+      <input type="radio" name="import-format" value="csv" bind:group={format} data-testid="import-format-csv" />
+      CSV
+    </label>
+    <label class="flex items-center gap-1">
+      <input type="radio" name="import-format" value="json" bind:group={format} data-testid="import-format-json" />
+      JSON
+    </label>
+  </div>
+
+  <textarea
+    bind:value={rawData}
+    {placeholder}
+    rows="5"
+    class="mt-2 w-full rounded-md border border-gray-300 p-2 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+    data-testid="import-event-input"
+  ></textarea>
+
+  <div class="mt-2 flex items-center gap-3">
+    <button
+      type="button"
+      onclick={handleImport}
+      disabled={rawData.trim() === ''}
+      class="rounded-md bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+      data-testid="import-event-button"
+    >
+      Import
+    </button>
+    {#if message}
+      <span class="text-xs {message.kind === 'ok' ? 'text-green-700' : 'text-red-700'}" data-testid="import-event-message">
+        {message.text}
+      </span>
+    {/if}
+  </div>
+</details>

--- a/src/stores/vsmIOStore.svelte.js
+++ b/src/stores/vsmIOStore.svelte.js
@@ -7,6 +7,8 @@ import {
   serializeVsm,
   deserializeVsm,
 } from '../infrastructure/VsmJsonRepository.js'
+import { deriveVsmFromEvents } from '../utils/import/deriveVsm.js'
+import { parseEventsFromCsv, parseEventsFromJson } from '../utils/import/eventAdapters.js'
 import { vsmDataStore } from './vsmDataStore.svelte.js'
 import { vsmUIStore } from './vsmUIStore.svelte.js'
 
@@ -131,6 +133,38 @@ function createVsmIOStore() {
         return true
       } catch (e) {
         console.error('Failed to import JSON:', e)
+        return false
+      }
+    },
+
+    /**
+     * Import a current-state map from a real-tooling event log (CSV or JSON).
+     * Derives a VSM from the events and loads it as the working map.
+     * @param {string} rawData - Raw CSV or JSON event log
+     * @param {'csv'|'json'} format
+     * @param {{name?: string, stageOrder?: string[]}} [options]
+     * @returns {boolean} Success status
+     */
+    importEventLog(rawData, format, options = {}) {
+      try {
+        const events =
+          format === 'csv' ? parseEventsFromCsv(rawData) : parseEventsFromJson(rawData)
+        const { steps, connections } = deriveVsmFromEvents(events, options)
+        if (steps.length === 0) return false
+        const now = new Date().toISOString()
+        vsmDataStore.loadMap({
+          id: crypto.randomUUID(),
+          name: options.name || 'Imported current state',
+          description: 'Derived from a real-tooling event log',
+          steps,
+          connections,
+          createdAt: now,
+          updatedAt: now,
+        })
+        vsmUIStore.clearUIState()
+        return true
+      } catch (e) {
+        console.error('Failed to import event log:', e)
         return false
       }
     },

--- a/src/utils/import/deriveVsm.js
+++ b/src/utils/import/deriveVsm.js
@@ -1,0 +1,164 @@
+/**
+ * Derive a value stream map from a real-tooling event log (P3).
+ *
+ * Maps recorded state-transition timestamps (one WorkItemEvent per stage visit)
+ * onto VSM steps, deriving process time, lead time, %C&A, queue size, and the
+ * forward/rework connections from the data rather than from estimates.
+ *
+ * Pure function. Source-agnostic: adapters normalize Jira/GitHub/CI/CSV/JSON
+ * into the WorkItemEvent shape, then this builds the map.
+ *
+ * @typedef {Object} WorkItemEvent
+ * @property {string} workItemId
+ * @property {string} stage
+ * @property {string} enteredAt - ISO timestamp
+ * @property {string} [exitedAt] - ISO timestamp
+ */
+
+import { createStep } from '../../models/StepFactory.js'
+import { createConnection } from '../../models/ConnectionFactory.js'
+import { STEP_TYPES } from '../../data/stepTypes.js'
+import { CANVAS_START_X, CANVAS_STEP_SPACING, CANVAS_Y } from '../../data/canvasConfig.js'
+
+const MS_PER_MIN = 60000
+
+const median = (values) => {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/** Time-weighted average number of overlapping intervals (a WIP proxy). */
+const averageConcurrency = (intervals) => {
+  const spans = intervals.filter(([start, end]) => end > start)
+  if (spans.length === 0) return 0
+  const points = [...new Set(spans.flatMap(([s, e]) => [s, e]))].sort((a, b) => a - b)
+  let weighted = 0
+  let total = 0
+  for (let i = 0; i < points.length - 1; i++) {
+    const segStart = points[i]
+    const segEnd = points[i + 1]
+    const len = segEnd - segStart
+    const count = spans.filter(([s, e]) => s <= segStart && e >= segEnd).length
+    weighted += count * len
+    total += len
+  }
+  return total > 0 ? weighted / total : 0
+}
+
+/** Best-effort step type from a stage name (improves downstream diagnostics). */
+const inferStepType = (name) => {
+  const n = name.toLowerCase()
+  if (/(test|qa)/.test(n)) return STEP_TYPES.TESTING
+  if (/(deploy|release|ship)/.test(n)) return STEP_TYPES.DEPLOYMENT
+  if (/review/.test(n)) return STEP_TYPES.CODE_REVIEW
+  if (/(plan|backlog|groom)/.test(n)) return STEP_TYPES.PLANNING
+  if (/(build|dev|code|implement)/.test(n)) return STEP_TYPES.DEVELOPMENT
+  if (/stag/.test(n)) return STEP_TYPES.STAGING
+  if (/monitor/.test(n)) return STEP_TYPES.MONITORING
+  return STEP_TYPES.CUSTOM
+}
+
+const toMs = (iso) => Date.parse(iso)
+
+/**
+ * Build a VSM from a flat list of work-item events.
+ * @param {WorkItemEvent[]} events
+ * @param {{stageOrder?: string[]}} [options]
+ * @returns {{steps: Array, connections: Array}}
+ */
+export function deriveVsmFromEvents(events = [], options = {}) {
+  const valid = events.filter(
+    (e) => e && e.workItemId && e.stage && Number.isFinite(toMs(e.enteredAt))
+  )
+  if (valid.length === 0) return { steps: [], connections: [] }
+
+  // --- Stage ordering ---
+  const seen = []
+  valid
+    .slice()
+    .sort((a, b) => toMs(a.enteredAt) - toMs(b.enteredAt))
+    .forEach((e) => {
+      if (!seen.includes(e.stage)) seen.push(e.stage)
+    })
+  const order = (options.stageOrder?.filter((s) => seen.includes(s)) || seen).slice()
+  const orderIndex = new Map(order.map((s, i) => [s, i]))
+
+  // --- Per-stage accumulators ---
+  const stageData = new Map(
+    order.map((s) => [s, { active: [], lead: [], intervals: [], items: new Set(), reentered: new Set() }])
+  )
+  const totalItems = new Set(valid.map((e) => e.workItemId))
+  const reworkCounts = new Map() // "from→to" -> Set(workItemId)
+
+  // --- Walk each item's timeline ---
+  const byItem = new Map()
+  valid.forEach((e) => {
+    if (!byItem.has(e.workItemId)) byItem.set(e.workItemId, [])
+    byItem.get(e.workItemId).push(e)
+  })
+
+  for (const [itemId, itemEvents] of byItem) {
+    itemEvents.sort((a, b) => toMs(a.enteredAt) - toMs(b.enteredAt))
+    itemEvents.forEach((e, i) => {
+      const data = stageData.get(e.stage)
+      if (!data) return
+      const enteredMs = toMs(e.enteredAt)
+      const next = itemEvents[i + 1]
+      const exitedMs = Number.isFinite(toMs(e.exitedAt)) ? toMs(e.exitedAt) : null
+      const nextEntryMs = next ? toMs(next.enteredAt) : null
+
+      const activeMs = (exitedMs ?? nextEntryMs ?? enteredMs) - enteredMs
+      const leadMs = (nextEntryMs ?? exitedMs ?? enteredMs) - enteredMs
+
+      data.active.push(Math.max(0, activeMs) / MS_PER_MIN)
+      data.lead.push(Math.max(0, leadMs) / MS_PER_MIN)
+      data.intervals.push([enteredMs, exitedMs ?? nextEntryMs ?? enteredMs])
+      if (data.items.has(itemId)) data.reentered.add(itemId)
+      data.items.add(itemId)
+
+      // Backward move = rework edge from the previous stage back to this one
+      if (next && orderIndex.get(next.stage) < orderIndex.get(e.stage)) {
+        const key = `${e.stage}→${next.stage}`
+        if (!reworkCounts.has(key)) reworkCounts.set(key, new Set())
+        reworkCounts.get(key).add(itemId)
+      }
+    })
+  }
+
+  // --- Steps ---
+  const steps = order.map((stage, i) => {
+    const data = stageData.get(stage)
+    const processTime = Math.round(median(data.active))
+    const leadTime = Math.max(processTime, Math.round(median(data.lead)))
+    const reentryRate = data.items.size > 0 ? data.reentered.size / data.items.size : 0
+    return createStep(stage, {
+      type: inferStepType(stage),
+      processTime,
+      leadTime,
+      percentCompleteAccurate: Math.round((1 - reentryRate) * 100),
+      queueSize: Math.round(averageConcurrency(data.intervals)),
+      position: { x: CANVAS_START_X + i * CANVAS_STEP_SPACING, y: CANVAS_Y },
+    })
+  })
+
+  const stepIdByStage = new Map(steps.map((s) => [s.name, s.id]))
+
+  // --- Connections: forward (consecutive) + rework (backward moves) ---
+  const connections = []
+  for (let i = 0; i < order.length - 1; i++) {
+    connections.push(
+      createConnection(stepIdByStage.get(order[i]), stepIdByStage.get(order[i + 1]), 'forward')
+    )
+  }
+  for (const [key, items] of reworkCounts) {
+    const [from, to] = key.split('→')
+    const reworkRate = Math.round((items.size / totalItems.size) * 100)
+    connections.push(
+      createConnection(stepIdByStage.get(from), stepIdByStage.get(to), 'rework', reworkRate)
+    )
+  }
+
+  return { steps, connections }
+}

--- a/src/utils/import/eventAdapters.js
+++ b/src/utils/import/eventAdapters.js
@@ -1,0 +1,59 @@
+/**
+ * Event-source adapters (P3).
+ *
+ * Thin parsers that normalize an exported event log into the WorkItemEvent
+ * shape consumed by deriveVsmFromEvents. The file-based CSV/JSON adapters are
+ * the working stand-in for live Jira/GitHub/CI adapters, which conform to the
+ * same shape but fetch over the network (see docs/specs/real-tooling-import.md).
+ */
+
+const FIELDS = ['workItemId', 'stage', 'enteredAt', 'exitedAt']
+
+const normalize = (raw) => {
+  const event = {
+    workItemId: raw.workItemId != null ? String(raw.workItemId) : undefined,
+    stage: raw.stage != null ? String(raw.stage) : undefined,
+    enteredAt: raw.enteredAt || undefined,
+  }
+  if (raw.exitedAt) event.exitedAt = raw.exitedAt
+  return event
+}
+
+/**
+ * Parse events from a JSON string (a top-level array, or `{ events: [...] }`).
+ * @param {string} jsonString
+ * @returns {Array}
+ */
+export function parseEventsFromJson(jsonString) {
+  try {
+    const data = JSON.parse(jsonString)
+    const list = Array.isArray(data) ? data : Array.isArray(data?.events) ? data.events : []
+    return list.map(normalize)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Parse events from a CSV string. The first non-blank line is the header;
+ * columns are mapped by name (workItemId, stage, enteredAt, exitedAt).
+ * @param {string} csvString
+ * @returns {Array}
+ */
+export function parseEventsFromCsv(csvString) {
+  const lines = String(csvString)
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== '')
+  if (lines.length < 2) return []
+
+  const header = lines[0].split(',').map((h) => h.trim())
+  return lines.slice(1).map((line) => {
+    const cells = line.split(',')
+    const row = {}
+    header.forEach((key, i) => {
+      const value = (cells[i] ?? '').trim()
+      if (FIELDS.includes(key) && value !== '') row[key] = value
+    })
+    return normalize(row)
+  })
+}

--- a/tests/unit/import/deriveVsm.test.js
+++ b/tests/unit/import/deriveVsm.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { deriveVsmFromEvents } from '../../../src/utils/import/deriveVsm'
+
+// Helper: ISO timestamp at `minutes` past a fixed epoch.
+const EPOCH = Date.parse('2026-01-01T00:00:00Z')
+const at = (minutes) => new Date(EPOCH + minutes * 60000).toISOString()
+
+const stepByName = (vsm, name) => vsm.steps.find((s) => s.name === name)
+
+describe('deriveVsmFromEvents', () => {
+  it('returns an empty map for no events', () => {
+    const vsm = deriveVsmFromEvents([])
+    expect(vsm.steps).toEqual([])
+    expect(vsm.connections).toEqual([])
+  })
+
+  it('creates one step per distinct stage in first-seen order', () => {
+    const events = [
+      { workItemId: '1', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+      { workItemId: '1', stage: 'Test', enteredAt: at(60), exitedAt: at(90) },
+    ]
+    const vsm = deriveVsmFromEvents(events)
+    expect(vsm.steps.map((s) => s.name)).toEqual(['Dev', 'Test'])
+  })
+
+  it('respects an explicit stage order', () => {
+    const events = [
+      { workItemId: '1', stage: 'Test', enteredAt: at(60), exitedAt: at(90) },
+      { workItemId: '1', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+    ]
+    const vsm = deriveVsmFromEvents(events, { stageOrder: ['Dev', 'Test'] })
+    expect(vsm.steps.map((s) => s.name)).toEqual(['Dev', 'Test'])
+  })
+
+  it('derives process time as the median active time in a stage', () => {
+    const events = [
+      { workItemId: '1', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+      { workItemId: '2', stage: 'Dev', enteredAt: at(0), exitedAt: at(120) },
+    ]
+    expect(stepByName(deriveVsmFromEvents(events), 'Dev').processTime).toBe(90)
+  })
+
+  it('derives lead time including the wait until the next stage', () => {
+    const events = [
+      { workItemId: '1', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+      // 40 min wait before Test starts
+      { workItemId: '1', stage: 'Test', enteredAt: at(100), exitedAt: at(130) },
+    ]
+    const dev = stepByName(deriveVsmFromEvents(events), 'Dev')
+    expect(dev.processTime).toBe(60)
+    expect(dev.leadTime).toBe(100)
+  })
+
+  it('connects consecutive stages with a forward connection', () => {
+    const events = [
+      { workItemId: '1', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+      { workItemId: '1', stage: 'Test', enteredAt: at(60), exitedAt: at(90) },
+    ]
+    const vsm = deriveVsmFromEvents(events)
+    const dev = stepByName(vsm, 'Dev')
+    const test = stepByName(vsm, 'Test')
+    const forward = vsm.connections.find((c) => c.type === 'forward')
+    expect(forward.source).toBe(dev.id)
+    expect(forward.target).toBe(test.id)
+  })
+
+  it('detects rework as a backward move and lowers %C&A of the revisited stage', () => {
+    const events = [
+      // Item returns to Dev after Test (rework)
+      { workItemId: '1', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+      { workItemId: '1', stage: 'Test', enteredAt: at(60), exitedAt: at(90) },
+      { workItemId: '1', stage: 'Dev', enteredAt: at(90), exitedAt: at(120) },
+      { workItemId: '2', stage: 'Dev', enteredAt: at(0), exitedAt: at(60) },
+      { workItemId: '2', stage: 'Test', enteredAt: at(60), exitedAt: at(90) },
+    ]
+    const vsm = deriveVsmFromEvents(events, { stageOrder: ['Dev', 'Test'] })
+    const dev = stepByName(vsm, 'Dev')
+    const test = stepByName(vsm, 'Test')
+
+    // 1 of 2 items returned to Dev → 50% reentry → %C&A 50
+    expect(dev.percentCompleteAccurate).toBe(50)
+
+    const rework = vsm.connections.find((c) => c.type === 'rework')
+    expect(rework.source).toBe(test.id)
+    expect(rework.target).toBe(dev.id)
+    expect(rework.reworkRate).toBe(50)
+  })
+
+  it('keeps lead time at least as large as process time', () => {
+    const events = [{ workItemId: '1', stage: 'Solo', enteredAt: at(0), exitedAt: at(45) }]
+    const solo = stepByName(deriveVsmFromEvents(events), 'Solo')
+    expect(solo.leadTime).toBeGreaterThanOrEqual(solo.processTime)
+  })
+})

--- a/tests/unit/import/eventAdapters.test.js
+++ b/tests/unit/import/eventAdapters.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { parseEventsFromJson, parseEventsFromCsv } from '../../../src/utils/import/eventAdapters'
+
+describe('parseEventsFromJson', () => {
+  it('parses a top-level array of events', () => {
+    const json = JSON.stringify([
+      { workItemId: '1', stage: 'Dev', enteredAt: '2026-01-01T00:00:00Z', exitedAt: '2026-01-01T01:00:00Z' },
+    ])
+    const events = parseEventsFromJson(json)
+    expect(events).toHaveLength(1)
+    expect(events[0].stage).toBe('Dev')
+  })
+
+  it('parses an object with an events array', () => {
+    const json = JSON.stringify({ events: [{ workItemId: '1', stage: 'Dev', enteredAt: '2026-01-01T00:00:00Z' }] })
+    expect(parseEventsFromJson(json)).toHaveLength(1)
+  })
+
+  it('returns an empty array for invalid JSON', () => {
+    expect(parseEventsFromJson('not json')).toEqual([])
+  })
+})
+
+describe('parseEventsFromCsv', () => {
+  it('parses rows using the header for column mapping', () => {
+    const csv = [
+      'workItemId,stage,enteredAt,exitedAt',
+      '1,Dev,2026-01-01T00:00:00Z,2026-01-01T01:00:00Z',
+      '1,Test,2026-01-01T01:00:00Z,2026-01-01T01:30:00Z',
+    ].join('\n')
+    const events = parseEventsFromCsv(csv)
+    expect(events).toHaveLength(2)
+    expect(events[0]).toMatchObject({ workItemId: '1', stage: 'Dev' })
+    expect(events[1].stage).toBe('Test')
+  })
+
+  it('tolerates a missing exitedAt column value', () => {
+    const csv = ['workItemId,stage,enteredAt,exitedAt', '1,Dev,2026-01-01T00:00:00Z,'].join('\n')
+    const events = parseEventsFromCsv(csv)
+    expect(events[0].exitedAt).toBeUndefined()
+  })
+
+  it('ignores blank lines', () => {
+    const csv = ['workItemId,stage,enteredAt', '', '1,Dev,2026-01-01T00:00:00Z', '   '].join('\n')
+    expect(parseEventsFromCsv(csv)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What

Implements **PR-A** from `docs/specs/real-tooling-import.md` — the feasible, fully-testable half of the real-tooling import feature. Teams can now **derive a measured value stream from an exported event log** instead of hand-entering guessed durations.

The live Jira/GitHub/CI network adapters remain design-only (they need external credentials), but they plug into the exact same `WorkItemEvent` contract this PR ships.

## How

- **`src/utils/import/deriveVsm.js`** — pure `deriveVsmFromEvents(events, { stageOrder })`. From state-transition timestamps it derives, per stage:
  - **process time** = median active time in stage
  - **lead time** = median time until the next stage (clamped ≥ process time)
  - **%C&A** = `100 × (1 − reentry rate)`
  - **queue size** = average concurrent WIP (time-weighted)
  - **forward connections** between consecutive stages, and **rework connections** from backward moves (with a data-derived rework rate)
  - infers step **type** from the stage name (test→testing, deploy→deployment, …) so the readiness scorecard/recommendations work on imported maps
- **`src/utils/import/eventAdapters.js`** — `parseEventsFromCsv` / `parseEventsFromJson` normalizing to `WorkItemEvent`.
- **`vsmIOStore.importEventLog(raw, format)`** — derives + loads the map through the existing `loadMap` path (undoable, re-exportable like any map).
- **`ImportEventLog.svelte`** — paste a CSV/JSON event log and import.

## Tests

- **14 unit tests** (8 engine: ordering, median process/lead, forward + rework, reentry %C&A, lead≥process; 6 adapters).
- **3 acceptance scenarios** (`features/data/import-event-log.feature`): CSV import + type inference, rework→connection, empty-log rejection.
- Gate green: **484 unit tests, build, lint**.

## Follow-ups (per the design doc)
PR-B/C/D add the live Jira / GitHub / CI adapters behind this same interface (fixture-tested, no live calls in CI). They change **no** derivation logic.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_