### PR TITLE
Make the VSM workshop usable on phones and tablets

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
   import { performUndo, performRedo } from './utils/undoHelper.js'
   import Header from './components/ui/Header.svelte'
   import Canvas from './components/canvas/Canvas.svelte'
+  import CanvasTotalsBar from './components/canvas/CanvasTotalsBar.svelte'
   import Sidebar from './components/ui/Sidebar.svelte'
   import MetricsDashboard from './components/metrics/MetricsDashboard.svelte'
   import CdReadinessScorecard from './components/metrics/CdReadinessScorecard.svelte'
@@ -22,6 +23,9 @@
   import SimulationControls from './components/simulation/SimulationControls.svelte'
   import Toast from './components/ui/Toast.svelte'
   import KeyboardShortcutsOverlay from './components/ui/KeyboardShortcutsOverlay.svelte'
+
+  // Off-canvas sidebar drawer (small screens)
+  let sidebarOpen = $state(false)
 
   // Keyboard shortcuts overlay (local state per D5)
   let showShortcuts = $state(false)
@@ -60,6 +64,9 @@
   let isEditing = $derived(vsmUIStore.isEditing)
   let selectedConnectionId = $derived(vsmUIStore.selectedConnectionId)
   let isEditingConnection = $derived(vsmUIStore.isEditingConnection)
+  let editorOpen = $derived(
+    (selectedStepId && isEditing) || (selectedConnectionId && isEditingConnection)
+  )
 
   function handleCanvasClick() {
     if (isEditing || isEditingConnection) return
@@ -92,12 +99,37 @@
 {:else}
   <SvelteFlowProvider>
     <div class="h-screen flex flex-col bg-gray-100">
-      <Header />
-      <div class="flex-1 flex overflow-hidden">
-        <Sidebar />
-        <main class="flex-1 flex flex-col" onclick={handleCanvasClick} onkeydown={handleCanvasKeyDown}>
+      <Header onMenuClick={() => (sidebarOpen = !sidebarOpen)} />
+      <div class="flex-1 flex overflow-hidden relative">
+        <!-- Backdrop for the mobile sidebar drawer -->
+        {#if sidebarOpen}
+          <button
+            type="button"
+            class="fixed inset-0 z-30 bg-black/30 lg:hidden"
+            aria-label="Close menu"
+            onclick={() => (sidebarOpen = false)}
+          ></button>
+        {/if}
+
+        <!-- Sidebar: static on desktop, slide-in drawer on phone/tablet -->
+        <div
+          class="fixed inset-y-0 left-0 z-40 transform transition-transform duration-200 lg:static lg:z-auto lg:translate-x-0 {sidebarOpen
+            ? 'translate-x-0'
+            : '-translate-x-full lg:translate-x-0'}"
+        >
+          <Sidebar onNavigate={() => (sidebarOpen = false)} />
+        </div>
+
+        <main
+          class="flex-1 flex flex-col overflow-y-auto"
+          onclick={handleCanvasClick}
+          onkeydown={handleCanvasKeyDown}
+        >
           <SimulationControls />
-          <div class="flex-1 relative">
+          <!-- Diagram gets a generous, fixed share of the viewport so it stays
+               usable on small screens; the totals bar stays overlaid. -->
+          <div class="relative shrink-0 h-[60vh] min-h-[320px] lg:h-[70vh]">
+            <CanvasTotalsBar />
             <Canvas />
           </div>
           <SimulationPanel />
@@ -112,14 +144,22 @@
           <FutureStatePanel />
           <ImportEventLog />
         </main>
-        <EditorPanel
-          {selectedStepId}
-          {isEditing}
-          {selectedConnectionId}
-          {isEditingConnection}
-          onCloseEditor={handleCloseEditor}
-          onCloseConnectionEditor={handleCloseConnectionEditor}
-        />
+
+        <!-- Editor: side panel on desktop, bottom sheet on phone/tablet -->
+        {#if editorOpen}
+          <div
+            class="fixed inset-x-0 bottom-0 z-40 max-h-[85vh] overflow-y-auto bg-white shadow-2xl lg:static lg:inset-auto lg:max-h-none lg:overflow-visible lg:shadow-none"
+          >
+            <EditorPanel
+              {selectedStepId}
+              {isEditing}
+              {selectedConnectionId}
+              {isEditingConnection}
+              onCloseEditor={handleCloseEditor}
+              onCloseConnectionEditor={handleCloseConnectionEditor}
+            />
+          </div>
+        {/if}
       </div>
     </div>
   </SvelteFlowProvider>

--- a/src/components/builder/ConnectionEditor.svelte
+++ b/src/components/builder/ConnectionEditor.svelte
@@ -74,7 +74,7 @@
 
 {#if connection}
   <div
-    class="w-80 bg-white border-l border-gray-200 p-4 overflow-y-auto"
+    class="w-full sm:w-80 bg-white border-l border-gray-200 p-4 overflow-y-auto"
     data-testid="connection-editor"
   >
     <div class="flex items-center justify-between mb-4">

--- a/src/components/builder/StepEditor.svelte
+++ b/src/components/builder/StepEditor.svelte
@@ -96,7 +96,7 @@
 
 {#if step}
   <div
-    class="w-80 bg-white border-l border-gray-200 p-4 overflow-y-auto"
+    class="w-full sm:w-80 bg-white border-l border-gray-200 p-4 overflow-y-auto"
     data-testid="step-editor"
   >
     <div class="flex items-center justify-between mb-4">

--- a/src/components/canvas/Canvas.svelte
+++ b/src/components/canvas/Canvas.svelte
@@ -219,6 +219,10 @@
     {defaultEdgeOptions}
     fitView
     fitViewOptions={{ padding: 0.2 }}
+    minZoom={0.2}
+    maxZoom={2}
+    zoomOnPinch
+    panOnScroll={false}
     snapToGrid
     snapGrid={[10, 10]}
     onconnect={handleConnect}
@@ -231,6 +235,7 @@
     <Background color="#e5e7eb" gap={20} />
     <Controls />
     <MiniMap
+      class="!hidden sm:!block"
       nodeColor={getNodeColor}
       maskColor="rgba(0, 0, 0, 0.1)"
     />

--- a/src/components/canvas/CanvasTotalsBar.svelte
+++ b/src/components/canvas/CanvasTotalsBar.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { vsmDataStore } from '../../stores/vsmDataStore.svelte.js'
+  import { selectCanvasTotals } from '../../utils/ui/canvasTotals.js'
+
+  let totals = $derived(selectCanvasTotals(vsmDataStore.metrics))
+
+  const statusText = {
+    good: 'text-green-700',
+    warning: 'text-amber-700',
+    critical: 'text-red-700',
+    neutral: 'text-gray-800',
+  }
+</script>
+
+<!-- Always-visible headline totals, overlaid on the diagram so they stay in
+     view while zooming/panning on phones and tablets. -->
+<div
+  class="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-2 pt-2"
+  data-testid="canvas-totals-bar"
+>
+  <div
+    class="pointer-events-auto flex max-w-full gap-2 overflow-x-auto rounded-full border border-gray-200 bg-white/95 px-3 py-1.5 shadow-sm backdrop-blur"
+  >
+    {#each totals as total (total.label)}
+      <div class="flex flex-none flex-col items-center px-2 leading-tight" data-testid="canvas-total-{total.label.toLowerCase().replace(/[^a-z]+/g, '-')}">
+        <span class="text-[10px] uppercase tracking-wide text-gray-400">{total.label}</span>
+        <span class="text-sm font-bold {statusText[total.status] || 'text-gray-800'}">{total.value}</span>
+      </div>
+    {/each}
+  </div>
+</div>

--- a/src/components/ui/Header.svelte
+++ b/src/components/ui/Header.svelte
@@ -7,6 +7,8 @@
   import { exportAsJson, exportAsPng, exportAsPdf } from '../../utils/export/index.js'
   import ConfirmPopover from './ConfirmPopover.svelte'
 
+  let { onMenuClick } = $props()
+
   let isEditingName = $state(false)
   let showNewMapConfirm = $state(false)
   let tempName = $state(vsmDataStore.name)
@@ -157,10 +159,22 @@
 </script>
 
 <header class="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-  <div class="flex items-center gap-4">
+  <div class="flex items-center gap-3 min-w-0">
+    {#if onMenuClick}
+      <button
+        onclick={onMenuClick}
+        class="lg:hidden -ml-1 rounded-md p-2 text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-label="Open menu"
+        data-testid="sidebar-toggle"
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+    {/if}
     <div class="flex items-center gap-2">
       <span class="text-xl">🗺️</span>
-      <span class="font-semibold text-gray-700">VSM Workshop</span>
+      <span class="hidden sm:inline font-semibold text-gray-700">VSM Workshop</span>
     </div>
     <div class="h-6 w-px bg-gray-300"></div>
     {#if isEditingName}
@@ -177,7 +191,7 @@
       <button
         onclick={handleNameClick}
         aria-label="Edit map name"
-        class="text-lg font-medium text-gray-800 hover:text-blue-600 transition-colors"
+        class="truncate max-w-[32vw] sm:max-w-none text-lg font-medium text-gray-800 hover:text-blue-600 transition-colors"
         data-testid="map-name"
       >
         {vsmDataStore.name}
@@ -185,7 +199,7 @@
     {/if}
   </div>
 
-  <div class="flex items-center gap-2">
+  <div class="flex shrink-0 items-center gap-1 sm:gap-2">
     <button
       onclick={performUndo}
       disabled={!undoStore.canUndo}

--- a/src/components/ui/Sidebar.svelte
+++ b/src/components/ui/Sidebar.svelte
@@ -9,6 +9,8 @@
   import { STEP_TYPE_CONFIG } from '../../data/stepTypeConfig.js'
   import { formatDuration } from '../../utils/calculations/metrics.js'
 
+  let { onNavigate } = $props()
+
   let expandedCategory = $state(null)
 
   const templatesByCategory = getTemplatesByCategory()
@@ -17,6 +19,7 @@
     const step = withUndo(() => vsmDataStore.addStep('New Step'))
     vsmUIStore.selectStep(step.id)
     vsmUIStore.setEditing(true)
+    onNavigate?.()
   }
 
   function handleAddFromTemplate(template) {
@@ -31,6 +34,7 @@
     }))
     vsmUIStore.selectStep(step.id)
     vsmUIStore.setEditing(true)
+    onNavigate?.()
   }
 
   function toggleCategory(category) {
@@ -42,7 +46,7 @@
   }
 </script>
 
-<aside class="w-64 bg-white border-r border-gray-200 p-4 overflow-y-auto flex flex-col" aria-label="Step templates and instructions">
+<aside class="h-full w-64 bg-white border-r border-gray-200 p-4 overflow-y-auto flex flex-col" aria-label="Step templates and instructions">
   <button
     onclick={handleAddStep}
     class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"

--- a/src/utils/ui/canvasTotals.js
+++ b/src/utils/ui/canvasTotals.js
@@ -1,0 +1,21 @@
+/**
+ * Key totals for the always-visible canvas totals bar.
+ *
+ * Pure selector so the mobile/tablet totals overlay shows a compact, consistent
+ * set of headline numbers without duplicating formatting logic.
+ */
+import { formatDuration } from '../calculations/metrics.js'
+
+/**
+ * @param {Object} metrics - Output of calculateMetrics
+ * @returns {Array<{label:string, value:string, status?:string}>}
+ */
+export function selectCanvasTotals(metrics = {}) {
+  const flowEfficiency = metrics.flowEfficiency || {}
+  return [
+    { label: 'Lead Time', value: formatDuration(metrics.totalLeadTime || 0) },
+    { label: 'Process Time', value: formatDuration(metrics.totalProcessTime || 0) },
+    { label: 'Flow Eff.', value: flowEfficiency.displayValue || 'N/A', status: flowEfficiency.status },
+    { label: 'Steps', value: String(metrics.stepCount ?? 0) },
+  ]
+}

--- a/tests/e2e/responsive.spec.js
+++ b/tests/e2e/responsive.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+const PHONE = { width: 390, height: 844 }
+const TABLET = { width: 768, height: 1024 }
+const DESKTOP = { width: 1280, height: 800 }
+
+async function createMap(page) {
+  await page.goto('/')
+  await page.evaluate(() => window.localStorage.clear())
+  await page.goto('/')
+  await page.getByTestId('new-map-name-input').fill('Responsive Map')
+  await page.getByTestId('create-map-button').click()
+}
+
+test.describe('Responsive layout (phone / tablet)', () => {
+  test('phone: totals bar is visible and the sidebar is a drawer', async ({ page }) => {
+    await page.setViewportSize(PHONE)
+    await createMap(page)
+
+    // Headline totals stay visible over the diagram.
+    await expect(page.getByTestId('canvas-totals-bar')).toBeVisible()
+    await expect(page.getByTestId('vsm-canvas')).toBeVisible()
+
+    // The sidebar is collapsed off-screen behind a hamburger toggle.
+    await expect(page.getByTestId('sidebar-toggle')).toBeVisible()
+    await expect(page.getByTestId('add-step-button')).not.toBeInViewport()
+
+    // Opening the drawer brings the sidebar on-screen.
+    await page.getByTestId('sidebar-toggle').click()
+    await expect(page.getByTestId('add-step-button')).toBeInViewport()
+  })
+
+  test('phone: zoom controls are available on the diagram', async ({ page }) => {
+    await page.setViewportSize(PHONE)
+    await createMap(page)
+    await expect(page.locator('.svelte-flow__controls-zoomin')).toBeVisible()
+    await expect(page.locator('.svelte-flow__controls-zoomout')).toBeVisible()
+    // Clicking zoom in should not throw and keeps the canvas visible.
+    await page.locator('.svelte-flow__controls-zoomin').click()
+    await expect(page.getByTestId('vsm-canvas')).toBeVisible()
+  })
+
+  test('tablet: totals visible, sidebar still a drawer below lg', async ({ page }) => {
+    await page.setViewportSize(TABLET)
+    await createMap(page)
+    await expect(page.getByTestId('canvas-totals-bar')).toBeVisible()
+    await expect(page.getByTestId('sidebar-toggle')).toBeVisible()
+    await expect(page.getByTestId('add-step-button')).not.toBeInViewport()
+  })
+
+  test('desktop: sidebar is static and the hamburger is hidden', async ({ page }) => {
+    await page.setViewportSize(DESKTOP)
+    await createMap(page)
+    await expect(page.getByTestId('add-step-button')).toBeInViewport()
+    await expect(page.getByTestId('sidebar-toggle')).toBeHidden()
+    await expect(page.getByTestId('canvas-totals-bar')).toBeVisible()
+  })
+})

--- a/tests/unit/utils/ui/canvasTotals.test.js
+++ b/tests/unit/utils/ui/canvasTotals.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { selectCanvasTotals } from '../../../../src/utils/ui/canvasTotals'
+
+const metrics = (overrides = {}) => ({
+  totalLeadTime: 240,
+  totalProcessTime: 60,
+  flowEfficiency: { displayValue: '25.0%', status: 'good' },
+  stepCount: 4,
+  ...overrides,
+})
+
+describe('selectCanvasTotals', () => {
+  it('returns the key totals in display order', () => {
+    const totals = selectCanvasTotals(metrics())
+    expect(totals.map((t) => t.label)).toEqual([
+      'Lead Time',
+      'Process Time',
+      'Flow Eff.',
+      'Steps',
+    ])
+  })
+
+  it('formats durations and passes through the flow-efficiency display value', () => {
+    const byLabel = Object.fromEntries(selectCanvasTotals(metrics()).map((t) => [t.label, t.value]))
+    expect(byLabel['Lead Time']).toBe('4h')
+    expect(byLabel['Process Time']).toBe('1h')
+    expect(byLabel['Flow Eff.']).toBe('25.0%')
+    expect(byLabel['Steps']).toBe('4')
+  })
+
+  it('carries the flow-efficiency status for color coding', () => {
+    const eff = selectCanvasTotals(metrics()).find((t) => t.label === 'Flow Eff.')
+    expect(eff.status).toBe('good')
+  })
+
+  it('handles an empty map safely', () => {
+    const totals = selectCanvasTotals(
+      metrics({
+        totalLeadTime: 0,
+        totalProcessTime: 0,
+        stepCount: 0,
+        flowEfficiency: { displayValue: 'N/A', status: 'neutral' },
+      })
+    )
+    const byLabel = Object.fromEntries(totals.map((t) => [t.label, t.value]))
+    expect(byLabel['Steps']).toBe('0')
+    expect(byLabel['Flow Eff.']).toBe('N/A')
+    expect(byLabel['Lead Time']).toBe('0m')
+  })
+})


### PR DESCRIPTION
## What

Fixes the tablet/phone UX so you can **visualize the value stream and metrics**, **zoom the diagram**, and keep the **totals always visible** on small screens.

### The problems (before)
- Fixed-width sidebar (`w-64`) + editor (`w-80`) crushed the canvas on phones/tablets.
- The panel column never scrolled and its row was `overflow-hidden`, so the metrics + diagnostic panels were **clipped and unreachable**.
- Totals lived in a dashboard **below the fold** — invisible while looking at the diagram.

### The fixes
- **Sidebar → slide-in drawer** below `lg` (hamburger in the header + tap-away backdrop); static side panel on desktop. Closes automatically after adding a step.
- **Editor → bottom sheet** on small screens (full-width `StepEditor`/`ConnectionEditor` under `sm`), side panel on desktop.
- **Scrollable layout**: the panel column now scrolls, and the **diagram gets a generous fixed share of the viewport** (`60vh`, `70vh` on `lg`) so it stays usable and every panel is reachable.
- **Always-visible totals**: a new `CanvasTotalsBar` overlays the diagram with the headline numbers — **Lead Time, Process Time, Flow Efficiency, Steps** (pure `selectCanvasTotals`), so they stay in view while zooming/panning.
- **Zoom**: explicit `minZoom`/`maxZoom` + pinch-to-zoom on touch; the on-canvas zoom Controls remain; MiniMap hidden on phones to declutter.
- **Header** no longer overflows on narrow screens (truncated map name, compact action cluster, logo text hidden under `sm`).

## Tests
- Unit: `selectCanvasTotals` (4 tests). Gate green: **488 unit tests, build, lint**.
- E2E: `tests/e2e/responsive.spec.js` asserts phone/tablet drawer behavior, visible totals bar, available zoom controls, and the desktop static sidebar.

## ⚠️ Verification note
I could **not screenshot-verify in the build sandbox** — the network policy blocks the Playwright browser download and there's no system Chromium. The change is build/lint/unit-verified and the e2e spec runs in your CI (where browsers are available). Worth a quick look on a real phone/tablet before merge; happy to adjust the diagram height fractions or which totals show if they don't feel right.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_