### PR TITLE
Add SessionStart hook to install Playwright Chromium (for self-validation)

### DIFF
--- a/.claude/install-playwright.sh
+++ b/.claude/install-playwright.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# install-playwright.sh — SessionStart hook that installs Playwright's Chromium
+# so Claude Code can run the e2e/visual suite and take screenshots to validate
+# UI changes in a web session.
+#
+# ── REQUIREMENTS ────────────────────────────────────────────────────────────
+# The container is ephemeral, so the browser must be (re)installed each session.
+# This only works if the environment's NETWORK ACCESS policy allows the download
+# host  cdn.playwright.dev  (Playwright's Chromium build) plus the package-manager
+# mirrors for Chromium's OS libraries (libnss3, libatk, ...). Configure that in
+# the environment settings → Network access → Custom. Docs:
+#   https://code.claude.com/docs/en/claude-code-on-the-web
+#
+# Fail-open: never blocks a session. Quiet no-op when Chromium is already present
+# or when the network policy blocks the download.
+#
+# Opt out:  export CLAUDE_SKIP_PLAYWRIGHT=1
+set -u
+
+log() { printf '[install-playwright] %s\n' "$*" >&2; }
+
+if [ "${CLAUDE_SKIP_PLAYWRIGHT:-0}" = "1" ]; then
+  log "skipped (CLAUDE_SKIP_PLAYWRIGHT=1)"
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+command -v npx >/dev/null 2>&1 || { log "npx not found; skipping"; exit 0; }
+
+# Already installed? (Playwright caches browsers under ~/.cache/ms-playwright)
+if ls "${HOME}/.cache/ms-playwright"/chromium-*/ >/dev/null 2>&1; then
+  log "chromium already present; nothing to do"
+  exit 0
+fi
+
+# Prefer installing OS deps too (needs apt/root + network). Fall back to the
+# browser-only install if --with-deps isn't permitted.
+log "installing Chromium…"
+if npx --yes playwright install --with-deps chromium >/tmp/playwright-install.log 2>&1 \
+  || npx --yes playwright install chromium >>/tmp/playwright-install.log 2>&1; then
+  log "Chromium installed"
+else
+  log "install failed — the network policy likely blocks cdn.playwright.dev."
+  log "see /tmp/playwright-install.log; allow the host in the environment's Network access settings."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/install-dev-team.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/install-playwright.sh\""
           }
         ]
       }


### PR DESCRIPTION
## What

Lets Claude run the **e2e/visual Playwright suite and take screenshots** to self-validate UI changes during web sessions. This is the repo-side half of enabling browser validation.

- `.claude/install-playwright.sh` — a SessionStart hook that installs Playwright's Chromium (with OS deps) once per session. Mirrors the existing `install-dev-team.sh`: **fail-open** (never blocks a session), **quiet no-op** when Chromium is already present, opt-out via `CLAUDE_SKIP_PLAYWRIGHT=1`.
- Registers it as a second `SessionStart` command in `.claude/settings.json`.

## ⚠️ Requires a network-policy change (only you can do this)

The hook can only succeed if the **environment's Network access** policy allows the download host. In the environment settings (web/desktop/mobile → your environment → **Network access → Custom**), allow:
- **`cdn.playwright.dev`** — Playwright's Chromium binary
- keep the **default package-manager allowlist** checked (apt mirrors for Chromium's shared libs like `libnss3`/`libatk`)

Docs: https://code.claude.com/docs/en/claude-code-on-the-web

Until that host is allowed, the hook just logs a helpful message and continues (verified: it exits 0 even offline).

## Verified here
- `settings.json` is valid JSON; the hook runs and fails open cleanly in this (network-restricted) sandbox.

Once this is merged **and** the network host is allowed, a fresh session will have Chromium available and I can screenshot-verify changes (e.g. the responsive UX in #15) at phone/tablet viewports.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2HWcB4vGNjQnVh1terpYe)_